### PR TITLE
[Fe] feat: Global styles(styled-reset install), ThemeProvider, BrowserRouter

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,6 +18,7 @@
         "react-router-dom": "^6.4.0",
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.5",
+        "styled-reset": "^4.4.2",
         "web-vitals": "^2.1.4"
       }
     },
@@ -15387,6 +15388,21 @@
         "react-is": ">= 16.8.0"
       }
     },
+    "node_modules/styled-reset": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.4.2.tgz",
+      "integrity": "sha512-VzVhEZHpO/CD/F5ZllqTAY+GTaKlNDZt5mTrtPf/kXZSe85+wMkhRIiPARgvCP9/HQMk+ZGaEWk1IkdP2SYAUQ==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/zacanger"
+      },
+      "peerDependencies": {
+        "styled-components": ">=4.0.0 || >=5.0.0"
+      }
+    },
     "node_modules/stylehacks": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
@@ -27878,6 +27894,12 @@
         "shallowequal": "^1.1.0",
         "supports-color": "^5.5.0"
       }
+    },
+    "styled-reset": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.4.2.tgz",
+      "integrity": "sha512-VzVhEZHpO/CD/F5ZllqTAY+GTaKlNDZt5mTrtPf/kXZSe85+wMkhRIiPARgvCP9/HQMk+ZGaEWk1IkdP2SYAUQ==",
+      "requires": {}
     },
     "stylehacks": {
       "version": "5.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "react-router-dom": "^6.4.0",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.5",
+    "styled-reset": "^4.4.2",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,5 +1,30 @@
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { ThemeProvider } from "styled-components";
+import Login from "./pages/Login";
+import SignUp from "./pages/SignUp";
+import Main from "./pages/Main";
+import { GlobalStyles } from "./styles";
+
 function App() {
-  return <div></div>;
+  return (
+    <div>
+      <ThemeProvider
+        theme={{
+          lightGrey: "#e2e6e8",
+          accent: "#38d9a9",
+        }}
+      >
+        <GlobalStyles />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Main />} />
+            <Route path="/signup" element={<SignUp />} />
+            <Route path="/login" element={<Login />} />
+          </Routes>
+        </BrowserRouter>
+      </ThemeProvider>
+    </div>
+  );
 }
 
 export default App;

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -1,0 +1,4 @@
+function Login() {
+  return <>로그인</>;
+}
+export default Login;

--- a/client/src/pages/SignUp.js
+++ b/client/src/pages/SignUp.js
@@ -1,0 +1,4 @@
+function SignUp() {
+  return <>회원가입</>;
+}
+export default SignUp;

--- a/client/src/styles.js
+++ b/client/src/styles.js
@@ -1,0 +1,27 @@
+import { createGlobalStyle } from "styled-components";
+import reset from "styled-reset";
+
+export const GlobalStyles = createGlobalStyle`
+  ${reset}
+  * {
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+  }
+  body {
+    font-size:14px;
+    font-family:'Open Sans', sans-serif;
+  }
+  input {
+    all:unset;
+  }
+  a {
+    text-decoration:none;
+    color:inherit;
+  }
+  button{
+    background-color: white;
+    cursor: pointer;
+  }
+  
+`;


### PR DESCRIPTION
1. 전역스타일 적용 
  - GlobalStyles로 전역 스타일 지정 
  - styled-reset 설치하여 기본스타일 reset되게 함
3. ThemeProvider로 전역 색상 사용가능하게 함
  - lightGrey 연한 회색 / accent 강조색 (teal 4)
4. BrowserRouter
  - Main, SignUp, Login 라우터 연결
 
#### 참고사항
- styled-reset 을 추가설치했으므로 client폴더 내에서 npm i 해주시면 됩니다