### PR TITLE
[BE] feat: update and delete program with apply and program image

### DIFF
--- a/server/src/main/java/com/codestates/team5/dailyclub/apply/entity/Apply.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/apply/entity/Apply.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -28,10 +30,12 @@ public class Apply extends Auditable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "program_id")
     private Program program;

--- a/server/src/main/java/com/codestates/team5/dailyclub/apply/repository/ApplyRepository.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/apply/repository/ApplyRepository.java
@@ -7,9 +7,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface ApplyRepository extends JpaRepository<Apply, Long> {
     @Query("select a from Apply a where a.program.id = :programId")
-    Page<Apply> findAllByCriteriaId(PageRequest pageRequest, @Param("programId") Long programId);
+    Page<Apply> findAllByProgramId(PageRequest pageRequest, @Param("programId") Long programId);
+
+    @Query("select a from Apply a where a.program.id = :programId")
+    List<Apply> findByProgramId(@Param("programId") Long programId);
 
     @Query("select a from Apply a where a.user.id = :userId")
     Page<Apply> findAllByUserId(PageRequest pageRequest, @Param("userId") Long userId);

--- a/server/src/main/java/com/codestates/team5/dailyclub/image/entity/ProgramImage.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/image/entity/ProgramImage.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -50,4 +49,11 @@ public class ProgramImage {
         program.getProgramImages().add(this);
     }
 
+    //비즈니스 메소드
+    public void updateProgramImage(ProgramImage programImage) {
+        this.size = programImage.getSize();
+        this.contentType = programImage.getContentType();
+        this.originalName = programImage.getOriginalName();
+        this.bytes = programImage.getBytes();
+    }
 }

--- a/server/src/main/java/com/codestates/team5/dailyclub/image/util/ImageUtils.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/image/util/ImageUtils.java
@@ -20,9 +20,10 @@ public class ImageUtils {
         byte[] bytes = imageFile.getBytes();
 
         return ProgramImage.builder()
-                    .size(size)
-                    .contentType(contentType)
-                    .originalName(originalName)
-                    .bytes(bytes).build();
+            .size(size)
+            .contentType(contentType)
+            .originalName(originalName)
+            .bytes(bytes)
+            .build();
     }
 }

--- a/server/src/main/java/com/codestates/team5/dailyclub/program/dto/ProgramDto.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/program/dto/ProgramDto.java
@@ -67,6 +67,9 @@ public class ProgramDto {
 
         @Schema(description = "최소 신청 가능 친절 %", example = "70")
         private Integer minKind;
+
+        @Schema(description = "프로그램 이미지 ID")
+        private Long programImageId;
     }
 
     @Schema(name = "프로그램 응답 API 스펙", title = "프로그램 응답 API 스펙")

--- a/server/src/main/java/com/codestates/team5/dailyclub/program/dto/SearchFilterDto.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/program/dto/SearchFilterDto.java
@@ -16,13 +16,13 @@ public class SearchFilterDto {
     @Schema(description = "검색 키워드")
     private String keyword;
 
-    @Schema(description = "지역")
+    @Schema(description = "지역", allowableValues = {"서울", "경기", "강원", "인천", "대전/충청", "대구/경북", "부산/울산/경남", "광주/전라", "제주"})
     private String location;
 
-    @Schema(description = "프로그램 시작 날짜", name = "program-date", pattern = "yyyy-MM-dd", example = "2022-09-18")
+    @Schema(description = "프로그램 시작 날짜", pattern = "yyyy-MM-dd", example = "2022-09-18")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate programDate;
 
-    @Schema(description = "프로그램 상태", allowableValues = {"POSSIBLE", "IMMINENT"})
+    @Schema(description = "프로그램 상태", allowableValues = {"모집중", "마감임박", "마감"})
     private String programStatus;
 }

--- a/server/src/main/java/com/codestates/team5/dailyclub/program/entity/Program.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/program/entity/Program.java
@@ -10,6 +10,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import javax.persistence.CascadeType;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -17,6 +19,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.validation.constraints.NotNull;
@@ -42,6 +45,7 @@ public class Program extends Auditable {
     @NotNull
     private String title;
 
+    @Lob
     @NotNull
     private String text;
 
@@ -57,16 +61,37 @@ public class Program extends Auditable {
     @NotNull
     private Integer minKind;
 
-
     @Builder.Default //@Builder 사용 시 초기값 설정
     @Convert(converter = ProgramStatusConverter.class)
     private ProgramStatus programStatus = ProgramStatus.POSSIBLE;
 
     @Builder.Default
-    @OneToMany(mappedBy = "program")
+    @OneToMany(mappedBy = "program", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<ProgramImage> programImages = new ArrayList<>();
 
 
+    //비즈니스 메서드
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    //update method
+    public void updateProgram(Program program) {
+        this.title = program.getTitle();
+        this.text = program.getText();
+        this.numOfRecruits = program.getNumOfRecruits();
+        this.location = program.getLocation();
+        this.programDate = program.getProgramDate();
+        this.minKind = program.getMinKind();
+    }
+
+    public void updateProgramStatus(Program.ProgramStatus programStatus) {
+        this.programStatus = programStatus;
+    }
+
+
+    //Enum class
     @Getter
     @AllArgsConstructor
     public enum ProgramStatus implements CommonEnum {
@@ -92,11 +117,5 @@ public class Program extends Auditable {
 
         private final String description;
     }
-
-    public void setUser(User user) {
-        this.user = user;
-
-    }
-
 }
 

--- a/server/src/main/java/com/codestates/team5/dailyclub/program/mapper/ProgramMapper.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/program/mapper/ProgramMapper.java
@@ -17,20 +17,33 @@ public interface ProgramMapper extends CommonMapper {
     //ProgramPostDto -> Program
     default Program programPostDtoToProgram(ProgramDto.Post post) {
         return Program.builder()
-                .title(post.getTitle())
-                .text(post.getText())
-                .numOfRecruits(post.getNumOfRecruits())
-                .location(EnumValueConvertUtils.ofDescription(Program.Location.class, post.getLocation()))
-                .programDate(post.getProgramDate())
-                .minKind(post.getMinKind())
-                .build();
+            .title(post.getTitle())
+            .text(post.getText())
+            .numOfRecruits(post.getNumOfRecruits())
+            .location(EnumValueConvertUtils.ofDescription(Program.Location.class, post.getLocation()))
+            .programDate(post.getProgramDate())
+            .minKind(post.getMinKind())
+            .build();
+    }
+
+    //ProgramPatchDto -> Program
+    default Program programPatchDtoToProgram(ProgramDto.Patch patch) {
+        return Program.builder()
+            .id(patch.getId())
+            .title(patch.getTitle())
+            .text(patch.getText())
+            .numOfRecruits(patch.getNumOfRecruits())
+            .location(EnumValueConvertUtils.ofDescription(Program.Location.class, patch.getLocation()))
+            .programDate(patch.getProgramDate())
+            .minKind(patch.getMinKind())
+            .build();
     }
 
     //ProgramList -> ProgramResponseDtoList
     default List<ProgramDto.Response> programListToProgramResponseDtoList(List<Program> programList) {
         return programList.stream()
-                .map(this::programToProgramResponseDto)
-                .collect(Collectors.toList());
+            .map(this::programToProgramResponseDto)
+            .collect(Collectors.toList());
     }
 
 }

--- a/server/src/main/java/com/codestates/team5/dailyclub/program/service/ProgramService.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/program/service/ProgramService.java
@@ -1,7 +1,10 @@
 package com.codestates.team5.dailyclub.program.service;
 
+import com.codestates.team5.dailyclub.apply.entity.Apply;
+import com.codestates.team5.dailyclub.apply.repository.ApplyRepository;
 import com.codestates.team5.dailyclub.image.entity.ProgramImage;
 import com.codestates.team5.dailyclub.image.repository.ProgramImageRepository;
+import com.codestates.team5.dailyclub.image.util.ImageUtils;
 import com.codestates.team5.dailyclub.program.dto.SearchFilterDto;
 import com.codestates.team5.dailyclub.program.entity.Program;
 import com.codestates.team5.dailyclub.program.repository.ProgramRepository;
@@ -12,6 +15,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
 
 @Service
 @Transactional
@@ -22,13 +29,14 @@ public class ProgramService {
     private final ProgramRepository programRepository;
     private final UserRepository userRepository;
     private final ProgramImageRepository programImageRepository;
+    private final ApplyRepository applyRepository;
 
     /**
      * 1. loginUserId로 User 엔티티 Proxy 조회
      * 2. Program 등록
      * 3. ProgramImage 등록
      */
-    public Program createProgram(Long loginUserId, Program program, ProgramImage programImage) {
+    public Program createProgram(Long loginUserId, Program program, MultipartFile imageFile) throws IOException {
         //User를 DB에 직접 조회하지 않고, proxy로 가져옴
         User user = userRepository.getReferenceById(loginUserId);
         log.info("userReferenceById : {}", user.getClass()); //User$HibernateProxy$~
@@ -39,28 +47,105 @@ public class ProgramService {
         //Program 등록
         Program createdProgram = programRepository.save(program);
 
-        //ProgramImage Entity 연관관계 설정 (양방향)
-        programImage.setProgram(createdProgram);
+        if (!imageFile.isEmpty()) {
+            ProgramImage programImage = ImageUtils.parseToProgramImage(imageFile);
 
-        //ProgramImage 등록
-        programImageRepository.save(programImage);
+            //ProgramImage Entity 연관관계 설정 (양방향)
+            programImage.setProgram(createdProgram);
+
+            //ProgramImage 등록
+            programImageRepository.save(programImage);
+        }
 
         return createdProgram;
     }
 
-    public void deleteProgram(Long programId) {
+    public Program updateProgram(Long loginUserId,
+                                 Program programFromPatchDto,
+                                 Long programImageId,
+                                 MultipartFile imageFile) throws IOException {
+        log.info("programId : {}", programFromPatchDto.getId());
 
+        //program persistence context 등록
+        Program findProgram
+            = programRepository.findById(programFromPatchDto.getId())
+            .orElseThrow(() ->
+                new RuntimeException("존재하지 않는 프로그램입니다.")
+            );
+        //programStatus 체크
+        Program.ProgramStatus programStatus
+            = checkProgramStatus(findProgram.getId(), programFromPatchDto.getNumOfRecruits());
+
+        //program dirty checking
+        findProgram.updateProgramStatus(programStatus);
+        findProgram.updateProgram(programFromPatchDto);
+
+        //programImage 처리
+        /**
+         *   등록 / 수정 시 이미지 존재 여부 (programImageId / imageFile null 여부로 판단)
+         * 1. x      x  -> 아무 작업 x
+         * 2. x      o  -> 이미지 새로 등록
+         * 3. o      x  -> 기존 이미지 삭제
+         * 4. o      o  -> 이미지 변경
+         */
+        if (programImageId == null && !imageFile.isEmpty()) {
+            //2번 : 이미지 새로 등록
+            ProgramImage programImage = ImageUtils.parseToProgramImage(imageFile);
+
+            //ProgramImage Entity 연관관계 설정 (양방향)
+            programImage.setProgram(findProgram);
+
+            //ProgramImage 등록
+            programImageRepository.save(programImage);
+        } else if (programImageId != null && imageFile.isEmpty()){
+            //3번 : 기존 이미지 삭제
+            programImageRepository.deleteById(programImageId);
+        } else if (programImageId != null && !imageFile.isEmpty()) {
+            //4번 : 이미지 변경
+            ProgramImage findProgramImage
+                = programImageRepository.findById(programImageId)
+                .orElseThrow(() ->
+                    new RuntimeException("존재하지 않는 프로그램 이미지입니다.")
+                );
+            ProgramImage programImage = ImageUtils.parseToProgramImage(imageFile);
+
+            //programImage dirty checking
+            findProgramImage.updateProgramImage(programImage);
+        }
+
+        return findProgram;
+    }
+
+    public void deleteProgram(Long programId) {
+        programRepository.deleteById(programId);
     }
 
     public Program findProgram(Long programId) {
         return programRepository.findById(programId)
-                    .orElseThrow(() ->
-                        new RuntimeException("존재하지 않는 프로그램입니다.")
-                    );
+            .orElseThrow(() ->
+                new RuntimeException("존재하지 않는 프로그램입니다.")
+            );
     }
 
     public Page<Program> findPrograms(int page, int size, SearchFilterDto searchFilterDto) {
+
         return null;
+    }
+
+    //programStatus 체크
+    public Program.ProgramStatus checkProgramStatus(Long programId, int numOfRecruits) {
+        List<Apply> appliesByProgramId = applyRepository.findByProgramId(programId);
+        int numOfApplicants = appliesByProgramId.size();
+        long ratio = (long) numOfApplicants / numOfRecruits;
+        if (ratio > 1) {
+            throw new RuntimeException("현재 신청인원보다 적은 모집인원으로 설정할 수 없습니다.");
+        } else if (ratio == 1) {
+            return Program.ProgramStatus.IMPOSSIBLE;
+        } else if (ratio >= 0.8 && ratio < 1) {
+            return Program.ProgramStatus.IMMINENT;
+        } else {
+            return Program.ProgramStatus.POSSIBLE;
+        }
     }
 
 

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -29,3 +29,7 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB


### PR DESCRIPTION
프로그램 업데이트와 삭제 관련 pr입니다.

### 삭제
프로그램과 단방향 연관관계인 Apply는 Apply entity에서 "@OnDelete" 처리했고, 
```java
    @OnDelete(action = OnDeleteAction.CASCADE)
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "program_id")
    private Program program;
```

양방향 연관관계인 ProgramImage는 Program entity에서 "CascadeType.REMOVE와 orphanRemoval = true"로 삭제 처리했습니다.
```java
    @Builder.Default
    @OneToMany(mappedBy = "program", cascade = CascadeType.REMOVE, orphanRemoval = true)
    private List<ProgramImage> programImages = new ArrayList<>();
```

### 업데이트
* 프로그램 업데이트 시 모집 인원 변경에 따른 programStatus(모집중, 모집임박, 마감) 변경하는 로직이 Programservice에 checkProgramStatus()에 있습니다.
* 프로그램 업데이트 시 이미지 등록 여부에 따라 다르게 동작하는 로직이 Programservice에 updateProgram()에 있습니다.

### 특이사항
프로그램 CRUD에 Apply 관련 로직이 필요해 기본적인 로직만 작성되어 있는데 더 자세한 로직은 Apply 작업 때 추가할 예정입니다.