### PR TITLE
[BE] fix: add mapstruct-lombok binding

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -36,6 +36,10 @@ dependencies {
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.11'
 
+	//mapstruct + lombok
+	implementation 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+	annotationProcessor "org.projectlombok:lombok-mapstruct-binding:0.2.0"
+
 	//mapstruct
 	implementation 'org.mapstruct:mapstruct:1.5.2.Final'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.2.Final'


### PR DESCRIPTION
Mapstruct와 Lombok 같이 쓸 때 build.gradle에서 순서에 따라 동작이 제대로 안되는 이슈가 있다고 합니다.
 그래서 Mapstruct와 Lombok을 binding 해주는 library를 추가해주는 pr입니다.