### PR TITLE
[FE] feat: 프로그램리스트 api수정, Img 처리, Pagenation/ ProgUpdate 수정/ redux-persist/ Logout

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -29,6 +29,7 @@
         "react-redux": "^8.0.4",
         "react-router-dom": "^6.4.0",
         "react-scripts": "5.0.1",
+        "redux-persist": "^6.0.0",
         "styled-components": "^5.3.5",
         "styled-reset": "^4.4.2",
         "typescript": "^4.8.3",
@@ -14799,6 +14800,14 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
+    },
     "node_modules/redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
@@ -27862,6 +27871,12 @@
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
+    },
+    "redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "requires": {}
     },
     "redux-thunk": {
       "version": "2.4.1",

--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "react-redux": "^8.0.4",
     "react-router-dom": "^6.4.0",
     "react-scripts": "5.0.1",
+    "redux-persist": "^6.0.0",
     "styled-components": "^5.3.5",
     "styled-reset": "^4.4.2",
     "typescript": "^4.8.3",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -25,7 +25,7 @@ const App: React.FC = () => {
       >
         <GlobalStyles />
         <BrowserRouter>
-          <Header isLoggedIn={true} />
+          <Header />
           <Routes>
             <Route path="/" element={<Main />} />
             <Route path="/signup" element={<SignUp />} />

--- a/client/src/InitProvider.tsx
+++ b/client/src/InitProvider.tsx
@@ -1,27 +1,4 @@
-import { getLocalStorage } from 'apis/localStorage';
 import axios from 'axios';
-
-const accessToken = getLocalStorage('access_token');
-const refreshToken = getLocalStorage('refresh_token');
-
-/** JWT 디코딩하여 만료시간 확인 - 미완료 */
-const parseJwt = (token: string | null) => {
-  if (token) return JSON.parse(window.atob(token.split('.')[1]));
-};
-
-export const AuthVerify = () => {
-  const decodedAccess = parseJwt(accessToken);
-  const decodedRefresh = parseJwt(refreshToken);
-  console.log(decodedAccess, decodedRefresh); // 해부된 토큰내부 확인
-
-  if (decodedAccess.exp * 1000 < Date.now()) {
-    return 'Access Token Expired';
-  }
-  if (decodedRefresh.exp * 1000 < Date.now()) {
-    return 'Refresh Token Expired';
-  }
-  return true;
-};
 
 /** refresh토큰으로 access토큰 발급받기 - 백엔드와 상의해봐야함 */
 export const requestAccessToken = async (refreshToken: any) => {

--- a/client/src/apis/api.ts
+++ b/client/src/apis/api.ts
@@ -3,8 +3,8 @@ import { getLocalStorage } from './localStorage';
 
 /** 기본 api 인스턴스 */
 const BaseInstance = axios.create({
-  baseURL: process.env.REACT_APP_DEV_TWO_URL,
-  // baseURL: process.env.REACT_APP_DEV_URL,
+  // baseURL: process.env.REACT_APP_DEV_TWO_URL,
+  baseURL: process.env.REACT_APP_DEV_URL,
 });
 
 /** 인증 필요한 api = 인스턴스 생성 후, interceptor에서 사용자인증(헤더담는) 작업 */
@@ -39,8 +39,8 @@ export const API = {
   },
 
   // Program 임시
-  getProgram: () => {
-    return BaseInstance({ method: 'GET', url: `/api/programs` });
+  getProgram: (URL: string) => {
+    return BaseInstance({ method: 'GET', url: URL });
   },
   getAProgram: (programId: number) => {
     return BaseInstance({ method: 'GET', url: `/api/programs/${programId}` });

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -3,14 +3,13 @@ import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { useAppDispatch, useAppSelector } from 'stores/hooks';
 import { searchActions } from 'stores/searchSlice';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCircleUser } from '@fortawesome/free-solid-svg-icons';
 import Logo from '../images/Logo.svg';
 import Pen from '../images/Pen.svg';
 import Message from '../images/Message.svg';
 import Search from '../images/Search.svg';
 import Profile from '../images/Profile.svg';
-import { fetchUserInfo } from 'stores/userInfoSlice';
+import { logoutUser } from 'stores/userInfoSlice';
+import { removeLocalStorage } from 'apis/localStorage';
 
 const HeaderContainer = styled.div`
   position: fixed;
@@ -97,8 +96,6 @@ const UserProfileImg = styled.div`
   width: 70px;
   height: 70px;
   margin-bottom: 15px;
-  border: 1px solid grey;
-  border-radius: 50%;
   cursor: pointer;
 `;
 const UserNickName = styled.div`
@@ -193,7 +190,7 @@ export default function Header() {
   const [InputValue, setInputValue] = useState('');
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const { isLoggedIn, loading, loginId, userId } = useAppSelector(
+  const { isLoggedIn, users, loading, loginId, userId } = useAppSelector(
     (state) => state.userInfo
   );
 
@@ -207,10 +204,11 @@ export default function Header() {
       // setInputValue(''); // input창만 비우고 싶은데 전달할 전역상태까지 비워져버림
     }
   };
-  const handelProfileClick = () => {
-    setIsOpened(!isopened);
-    dispatch(fetchUserInfo()); //유저정보조회 thunk실행 전역상태에 저장 -안됨
-    // dispatch(fetchUserInfo(userId));//api 만약 userId로 변경시
+  const handleLogoutBtn = () => {
+    dispatch(logoutUser());
+    removeLocalStorage('access_token');
+    removeLocalStorage('refresh_token');
+    setIsOpened(false);
   };
 
   return (
@@ -259,9 +257,9 @@ export default function Header() {
                   </Link>
                 </Icon>
                 <Icon>
-                  <ProfileBtn onClick={handelProfileClick}>
+                  <ProfileBtn onClick={() => setIsOpened(!isopened)}>
                     <img
-                      src={Profile}
+                      src={users ? null : Profile}
                       alt="profile"
                       style={{ height: 25, width: 25 }}
                     />
@@ -279,9 +277,20 @@ export default function Header() {
           <WrapParent>
             <WrapChild>
               <UserContent>
-                <UserProfileImg>
-                  <Link to="/mypage"></Link>
-                </UserProfileImg>
+                <Link to="/mypage">
+                  <UserProfileImg>
+                    <img
+                      src={users ? null : Profile}
+                      alt="userImg"
+                      style={{
+                        height: 70,
+                        width: 70,
+                        border: '1px solid grey',
+                        borderRadius: '50%',
+                      }}
+                    />
+                  </UserProfileImg>
+                </Link>
                 <UserNickName>닉네임</UserNickName>
                 <Link to="/mypage">
                   <MyPageBtn>마이페이지</MyPageBtn>
@@ -304,7 +313,7 @@ export default function Header() {
                     </Notification>
                   ))}
                 </Notifications>
-                <LogoutBtn>로그아웃</LogoutBtn>
+                <LogoutBtn onClick={handleLogoutBtn}>로그아웃</LogoutBtn>
               </NotificationContainer>
             </WrapChild>
           </WrapParent>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import { useAppDispatch } from 'stores/hooks';
+import { useAppDispatch, useAppSelector } from 'stores/hooks';
 import { searchActions } from 'stores/searchSlice';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleUser } from '@fortawesome/free-solid-svg-icons';
@@ -10,6 +10,7 @@ import Pen from '../images/Pen.svg';
 import Message from '../images/Message.svg';
 import Search from '../images/Search.svg';
 import Profile from '../images/Profile.svg';
+import { fetchUserInfo } from 'stores/userInfoSlice';
 
 const HeaderContainer = styled.div`
   position: fixed;
@@ -160,8 +161,7 @@ const LogoutBtn = styled.button`
     background-color: #a8ddcb;
   }
 `;
-
-export default function Header({ isLoggedIn }: { isLoggedIn: boolean }) {
+export default function Header() {
   interface NotifyList {
     id: number;
     confirmed: boolean;
@@ -191,8 +191,11 @@ export default function Header({ isLoggedIn }: { isLoggedIn: boolean }) {
 
   const [isopened, setIsOpened] = useState<boolean>(false);
   const [InputValue, setInputValue] = useState('');
-  const dispatch = useAppDispatch();
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const { isLoggedIn, loading, loginId, userId } = useAppSelector(
+    (state) => state.userInfo
+  );
 
   const handelSearchSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -203,6 +206,11 @@ export default function Header({ isLoggedIn }: { isLoggedIn: boolean }) {
       navigate('/'); // 엔터 시 질문목록 메인페이지로 이동
       // setInputValue(''); // input창만 비우고 싶은데 전달할 전역상태까지 비워져버림
     }
+  };
+  const handelProfileClick = () => {
+    setIsOpened(!isopened);
+    dispatch(fetchUserInfo()); //유저정보조회 thunk실행 전역상태에 저장 -안됨
+    // dispatch(fetchUserInfo(userId));//api 만약 userId로 변경시
   };
 
   return (
@@ -251,7 +259,7 @@ export default function Header({ isLoggedIn }: { isLoggedIn: boolean }) {
                   </Link>
                 </Icon>
                 <Icon>
-                  <ProfileBtn onClick={() => setIsOpened(!isopened)}>
+                  <ProfileBtn onClick={handelProfileClick}>
                     <img
                       src={Profile}
                       alt="profile"

--- a/client/src/images/ImgDeleteBtn.svg
+++ b/client/src/images/ImgDeleteBtn.svg
@@ -1,0 +1,4 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="13.5" cy="14.5" r="12.5" fill="white"/>
+<path d="M14 0C6.2 0 0 6.2 0 14C0 21.8 6.2 28 14 28C21.8 28 28 21.8 28 14C28 6.2 21.8 0 14 0ZM19.4 21L14 15.6L8.6 21L7 19.4L12.4 14L7 8.6L8.6 7L14 12.4L19.4 7L21 8.6L15.6 14L21 19.4L19.4 21Z" fill="#6C6C6C"/>
+</svg>

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -3,12 +3,17 @@ import ReactDOM from 'react-dom/client';
 import { Provider } from 'react-redux';
 import store from 'stores/store';
 import App from './App';
+import { PersistGate } from 'redux-persist/integration/react';
+import { persistStore } from 'redux-persist';
+let persistor = persistStore(store);
 
 const root = ReactDOM.createRoot(document.getElementById('root')!);
 root.render(
   <React.StrictMode>
     <Provider store={store}>
-      <App />
+      <PersistGate loading={null} persistor={persistor}>
+        <App />
+      </PersistGate>
     </Provider>
   </React.StrictMode>
 );

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -66,7 +66,7 @@ export default function Login() {
           setLocalStorage('refresh_token', refreshToken);
           // API 요청마다 헤더에 access토큰 담아서 요청보내는 설정
           axios.defaults.headers.common['Authorization'] = `${accessToken}`;
-          axios.defaults.headers.common['Refresh'] = `${refreshToken}`;
+          // axios.defaults.headers.common['Refresh'] = `${refreshToken}`;
           navigate('/');
 
           //JWT디코딩해서 userId, loginId 등 전역상태
@@ -76,6 +76,7 @@ export default function Login() {
         }
       })
       .then(() => {
+        dispatch(fetchUserInfo()); // 로그인 후, 로그인한 유저정보조회
         // dispatch(fetchUserInfo(decodedAccess.id));//유저조회 thunk 전역상태에 저장
       })
       .catch((error) => console.log(error));

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -42,7 +42,7 @@ const FormError = styled.div`
 `;
 
 export default function Login() {
-  const URL = process.env.REACT_APP_DEV_TWO_URL;
+  const URL = process.env.REACT_APP_DEV_URL;
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const {
@@ -65,8 +65,8 @@ export default function Login() {
           setLocalStorage('access_token', accessToken);
           setLocalStorage('refresh_token', refreshToken);
           // API 요청마다 헤더에 access토큰 담아서 요청보내는 설정
-          axios.defaults.headers.common['Authorization'] = `${accessToken}`;
-          axios.defaults.headers.common['Refresh'] = `${refreshToken}`;
+          // axios.defaults.headers.common['Authorization'] = `${accessToken}`;
+          // axios.defaults.headers.common['Refresh'] = `${refreshToken}`;
           navigate('/');
 
           //JWT디코딩해서 userId, loginId 등 전역상태

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -66,17 +66,17 @@ export default function Login() {
           setLocalStorage('access_token', accessToken); // 토큰 localStorage에 저장
           setLocalStorage('refresh_token', refreshToken); // 토큰 localStorage에 저장
           // API 요청마다 헤더에 access토큰 담아서 요청보내는 설정
-          axios.defaults.headers.common[
-            'Authorization'
-          ] = `Bearer ${accessToken}`;
+          axios.defaults.headers.common['Authorization'] = `${accessToken}`;
           navigate('/');
         }
       })
-      .then(() => {
-        // console.log('로그인 응답 :', res);
+      .then((res) => {
+        console.log('로그인 응답 :', res);
         // const userId = res.data.userId // res로 받으면 주석해제
-
-        dispatch(fetchUserInfo(4)); //유저정보 전역상태에 저장 - 안됨
+        // axios
+        //   .get(`${URL}/api/users/mypage`)
+        //   .then((res) => console.log(res.data));
+        dispatch(fetchUserInfo()); //유저정보 전역상태에 저장 - 안됨
       })
       .catch((error) => console.log(error));
 

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -65,8 +65,8 @@ export default function Login() {
           setLocalStorage('access_token', accessToken);
           setLocalStorage('refresh_token', refreshToken);
           // API 요청마다 헤더에 access토큰 담아서 요청보내는 설정
-          // axios.defaults.headers.common['Authorization'] = `${accessToken}`;
-          // axios.defaults.headers.common['Refresh'] = `${refreshToken}`;
+          axios.defaults.headers.common['Authorization'] = `${accessToken}`;
+          axios.defaults.headers.common['Refresh'] = `${refreshToken}`;
           navigate('/');
 
           //JWT디코딩해서 userId, loginId 등 전역상태

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -12,6 +12,8 @@ import { Link } from 'react-router-dom';
 import { useAppSelector } from 'stores/hooks';
 import { getisLoggedIn, getUserData, getUserError } from 'stores/userInfoSlice';
 import BasicImg from '../images/BasicImg.jpg';
+import Pagination from 'pagination/Pagination';
+import { ProgramDetailVal } from 'types/programs';
 
 const WrapContainer = styled.div`
   margin-bottom: 5rem;
@@ -90,6 +92,7 @@ const WrapLevelText = styled.div`
 const ProgContainer = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
+  margin-bottom: 3rem;
 `;
 const ProgItem = styled.div`
   margin: 0.7rem 0.7rem 0.7rem 0;
@@ -131,25 +134,10 @@ const ProgWrapper = styled.div`
 `;
 const ProgPerson = styled.div``;
 const ProgDate = styled.div``;
-
 const DoneContainer = styled.div`
   padding: 7rem 0;
 `;
 
-interface ProgProps {
-  id: number;
-  programStatus: string;
-  title: string;
-  text: string;
-  programImages?: any; // 추가예정
-  minKind: number;
-  currentPerson: number; // api엔 없음
-  numOfRecruits: number;
-  location: string;
-  programDate: string;
-  bookmarkId?: number | null;
-  writer: string; // 수정
-}
 export default function Main() {
   const URL = process.env.REACT_APP_DEV_URL;
 
@@ -158,7 +146,10 @@ export default function Main() {
   const [areaSelected, setAreaSelected] = useState('');
   const [rangeValue, setRangeValue] = useState('');
   const [dateSelected, setDateSelected] = useState('');
-  const [programs, setPrograms] = useState<Array<Object>>([]);
+  const [programs, setPrograms] = useState<Array<ProgramDetailVal>>([]);
+  const [pageList, setPageList] = useState();
+  const [page, setPage] = useState<number>(1);
+
   // console.log(searchKeyword); // input값 전역상태에서 가져온거 확인용
 
   /** 유저 전역상태 전체 - users, isLoggedId, loading, error  */
@@ -175,26 +166,19 @@ export default function Main() {
   useEffect(() => {
     const getProgramList = async () => {
       await axios
-        .get(`${URL}/api/programs?page=1&size=10`)
+        .get(`${URL}/api/programs?page=${page}&size=10`)
         // .get(
         //   `${URL}/api/programs?page=1&size=10
         // &keyword=${searchKeyword}&location=${areaSelected}&minKind=${rangeValue}&programDate=${dateSelected}&programStatus=POSSIBLE`
         // )
         .then(({ data }) => {
           setPrograms(data?.data);
+          setPageList(data?.pageInfo);
         })
         .catch((err) => console.log(err.message));
     };
     getProgramList();
   }, []);
-
-  const progFilterProps = {
-    keyword: '',
-    location: areaSelected,
-    programDate: dateSelected,
-    levelRange: rangeValue, // api문서엔 없음
-  };
-  // console.log(progFilterProps); // 필터조회api 보낼때 객체
 
   return (
     <Layout>
@@ -264,7 +248,7 @@ export default function Main() {
                             : `data:${el.programImages[0].contentType};base64,${el?.programImages[0].bytes}`
                         }
                         style={{
-                          height: '130px',
+                          height: '180px',
                           width: '100%',
                           borderRadius: '5px',
                         }}
@@ -300,6 +284,7 @@ export default function Main() {
                 </Link>
               ))}
           </ProgContainer>
+          <Pagination list={pageList} page={page} setPage={setPage} />
         </IngContainer>
         <DoneContainer>
           <RecruitText>모집 마감된 모임</RecruitText>
@@ -316,7 +301,7 @@ export default function Main() {
                           : `data:${el.programImages[0].contentType};base64,${el?.programImages[0].bytes}`
                       }
                       style={{
-                        height: '130px',
+                        height: '180px',
                         width: '100%',
                         borderRadius: '5px',
                       }}

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -11,6 +11,7 @@ import ProgressBar from 'components/ProgressBar';
 import { Link } from 'react-router-dom';
 import { useAppSelector } from 'stores/hooks';
 import { getisLoggedIn, getUserData, getUserError } from 'stores/userInfoSlice';
+import BasicImg from '../images/BasicImg.jpg';
 
 const WrapContainer = styled.div`
   margin-bottom: 5rem;
@@ -92,11 +93,6 @@ const ProgContainer = styled.div`
 `;
 const ProgItem = styled.div`
   margin: 0.7rem 0.7rem 0.7rem 0;
-`;
-const ProgImg = styled.div`
-  background-color: gray;
-  height: 130px;
-  border-radius: 5px;
 `;
 const ProgBanner = styled.div`
   position: relative;
@@ -261,7 +257,19 @@ export default function Main() {
                       >
                         {el?.programStatus}
                       </ProgRecruitment>
-                      <ProgImg>사진</ProgImg>
+                      <img
+                        src={
+                          el?.programImages.length === 0
+                            ? BasicImg
+                            : `data:${el.programImages[0].contentType};base64,${el?.programImages[0].bytes}`
+                        }
+                        style={{
+                          height: '130px',
+                          width: '100%',
+                          borderRadius: '5px',
+                        }}
+                        alt="program Image"
+                      />
                       <ProgBookmark>
                         <img src={Bookmark} alt="bookmark" />
                       </ProgBookmark>
@@ -301,7 +309,19 @@ export default function Main() {
                 <ProgItem key={el.id}>
                   <ProgBanner>
                     <ProgRecruitment>모집종료</ProgRecruitment>
-                    <ProgImg>사진</ProgImg>
+                    <img
+                      src={
+                        el?.programImages.length === 0
+                          ? BasicImg
+                          : `data:${el.programImages[0].contentType};base64,${el?.programImages[0].bytes}`
+                      }
+                      style={{
+                        height: '130px',
+                        width: '100%',
+                        borderRadius: '5px',
+                      }}
+                      alt="program Image"
+                    />
                     <ProgBookmark>
                       <img src={Bookmark} alt="bookmark" />
                     </ProgBookmark>

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -10,7 +10,7 @@ import LevelPercent from 'components/LevelPercent';
 import ProgressBar from 'components/ProgressBar';
 import { Link } from 'react-router-dom';
 import { useAppSelector } from 'stores/hooks';
-import { getisLoggedId, getUserData, getUserError } from 'stores/userInfoSlice';
+import { getisLoggedIn, getUserData, getUserError } from 'stores/userInfoSlice';
 
 const WrapContainer = styled.div`
   margin-bottom: 5rem;
@@ -170,7 +170,7 @@ export default function Main() {
   // console.log('유저 전역정보: ', loginUserInfo ?? loginUserInfo);  // 확인용
 
   /** 유저 전역상태 1개씩 - isLoggedId, users, error */
-  const isLoggedId = useAppSelector(getisLoggedId); // 로그인여부
+  const isLoggedId = useAppSelector(getisLoggedIn); // 로그인여부
   const userData = useAppSelector(getUserData); // 유저정보
   const userError = useAppSelector(getUserError); // 에러내용
   // console.log('유저 전역상태: ', isLoggedId, userData, userError); // 확인 후 주석해제하면 됩니다
@@ -185,7 +185,6 @@ export default function Main() {
         // &keyword=${searchKeyword}&location=${areaSelected}&minKind=${rangeValue}&programDate=${dateSelected}&programStatus=POSSIBLE`
         // )
         .then(({ data }) => {
-          // console.log(data);
           setPrograms(data?.data);
         })
         .catch((err) => console.log(err.message));

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -154,7 +154,7 @@ export default function Main() {
 
   /** 유저 전역상태 전체 - users, isLoggedId, loading, error  */
   const loginUserInfo = useAppSelector((state) => state.userInfo);
-  // console.log('유저 전역정보: ', loginUserInfo ?? loginUserInfo);  // 확인용
+  // console.log('유저 전역정보: ', loginUserInfo ?? loginUserInfo); // 확인용
 
   /** 유저 전역상태 1개씩 - isLoggedId, users, error */
   const isLoggedId = useAppSelector(getisLoggedIn); // 로그인여부

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -145,18 +145,17 @@ interface ProgProps {
   programStatus: string;
   title: string;
   text: string;
-  // programImages?: string; // 추가예정
+  programImages?: any; // 추가예정
   minKind: number;
   currentPerson: number; // api엔 없음
   numOfRecruits: number;
   location: string;
   programDate: string;
-  bookmarkId?: number;
+  bookmarkId?: number | null;
   writer: string; // 수정
 }
 export default function Main() {
-  // const URL = process.env.REACT_APP_DEV_URL;
-  const URL = `http://localhost:3001`; // json-server
+  const URL = process.env.REACT_APP_DEV_URL;
 
   const searchKeyword = useAppSelector((state) => state.search.keyword);
   const [levelOpened, setLevelOpened] = useState(false);
@@ -174,20 +173,20 @@ export default function Main() {
   const isLoggedId = useAppSelector(getisLoggedId); // 로그인여부
   const userData = useAppSelector(getUserData); // 유저정보
   const userError = useAppSelector(getUserError); // 에러내용
-  console.log('유저 전역상태: ', isLoggedId, userData, userError); // 확인 후 주석해제하면 됩니다
+  // console.log('유저 전역상태: ', isLoggedId, userData, userError); // 확인 후 주석해제하면 됩니다
 
   /** 필터 조회api - 키워드,지역,날짜,친절도*/
-  // .get(
-  //   `${URL}/api/programs?page=1&size=10
-  // &keyword=${searchKeyword}&location=${areaSelected}&programDate=${dateSelected}&programStatus=POSSIBLE`
-  // )
-
   useEffect(() => {
     const getProgramList = async () => {
       await axios
-        .get(`${URL}/programs`)
+        .get(`${URL}/api/programs?page=1&size=10`)
+        // .get(
+        //   `${URL}/api/programs?page=1&size=10
+        // &keyword=${searchKeyword}&location=${areaSelected}&minKind=${rangeValue}&programDate=${dateSelected}&programStatus=POSSIBLE`
+        // )
         .then(({ data }) => {
-          setPrograms(data);
+          // console.log(data);
+          setPrograms(data?.data);
         })
         .catch((err) => console.log(err.message));
     };
@@ -261,7 +260,7 @@ export default function Main() {
                           }`,
                         }}
                       >
-                        {el.programStatus}
+                        {el?.programStatus}
                       </ProgRecruitment>
                       <ProgImg>사진</ProgImg>
                       <ProgBookmark>
@@ -274,13 +273,13 @@ export default function Main() {
                     <LevelPercent percent={el.minKind} />
                     <ProgProgressBar>
                       <ProgressBar
-                        currentPerson={el.currentPerson}
+                        currentPerson={el.numOfRecruits}
                         totalPerson={el.numOfRecruits}
                       />
                     </ProgProgressBar>
                     <ProgWrapper>
                       <ProgPerson>
-                        모집인원 {el.currentPerson} / {el.numOfRecruits}
+                        모집인원 {el.numOfRecruits} / {el.numOfRecruits}
                       </ProgPerson>
                       <ProgDate>
                         {Math.floor(

--- a/client/src/pages/ProgUpdate.tsx
+++ b/client/src/pages/ProgUpdate.tsx
@@ -247,6 +247,11 @@ function ProgUpdate() {
       .get(`${URL}/api/programs/${programId}`)
       .then(({ data }) => {
         setPrev(data);
+        setTitle(data?.title);
+        setText(data?.text);
+        setNumOfRecruits(data?.numOfRecruits);
+        setLocation(data?.location);
+        setProgramDate(data?.programDate);
         setMinKind(data?.minKind);
 
         /** 이전이미지 있으면, 이미지 받아오기 */
@@ -378,11 +383,10 @@ function ProgUpdate() {
             {/* 제목 인풋입니다 */}
             <TitleInput
               type="text"
-              defaultValue={prev && prev?.title}
+              defaultValue={title}
               name="title"
               ref={firstRef}
               onKeyUp={handleInput}
-              required
               onChange={handleTitle}
             />
             <ProgramInfoTitle>
@@ -392,10 +396,9 @@ function ProgUpdate() {
             {/* 프로그램 설명 인풋입니다 */}
             <ContentsInput
               name="contents"
-              defaultValue={prev && prev?.text}
+              defaultValue={text}
               ref={secondRef}
               onChange={handleText}
-              required
             />
           </ProgramInfo>
           <RecruitInfo>
@@ -412,8 +415,7 @@ function ProgUpdate() {
                 min="2"
                 name="people"
                 onChange={handleNumofRecruits}
-                required
-                defaultValue={prev && prev?.numOfRecruits}
+                defaultValue={numOfRecruits}
               />
             </RecruitContents>
             <RecruitContents>
@@ -424,8 +426,7 @@ function ProgUpdate() {
                 type="date"
                 name="date"
                 onChange={handleProgramDate}
-                required
-                defaultValue={prev && prev?.programDate}
+                defaultValue={programDate}
               />
             </RecruitContents>
             <RecruitContents>
@@ -434,8 +435,8 @@ function ProgUpdate() {
               <AreaSelect
                 name="area"
                 onChange={handleLocation}
-                key={prev && prev?.location}
-                defaultValue={prev && prev?.location}
+                key={location}
+                defaultValue={location}
               >
                 <option value="지역">지역</option>
                 <option value="서울">서울</option>
@@ -461,9 +462,8 @@ function ProgUpdate() {
                   step="1"
                   name="kind"
                   onChange={handleMinKindValue}
-                  required
                   key={prev && prev?.minKind}
-                  defaultValue={prev && prev?.minKind}
+                  defaultValue={minkind}
                 />
                 <KindValue>{minkind}%</KindValue>
               </KindInputWrap>

--- a/client/src/pages/ProgUpdate.tsx
+++ b/client/src/pages/ProgUpdate.tsx
@@ -242,23 +242,25 @@ function ProgUpdate() {
       .then(({ data }) => {
         setPrev(data);
         setMinKind(data?.minKind);
-        setPrevImgId(data?.programImages && data?.programImages[0].id); // 이전 img Id
 
         /** 이전이미지 있으면, 이미지 받아오기 */
-        if (data?.programImages[0].imageFile !== null || undefined) {
+        if (data?.programImages.length !== 0) {
           setPicture(
             `data:${data.programImages[0].contentType};base64,${data?.programImages[0].bytes}`
           );
           setImagePreview(
             `data:${data.programImages[0].contentType};base64,${data?.programImages[0].bytes}`
           );
-        } else {
-          /** 이전이미지 없으면 이미지 추가 */
+          setPrevImgId(data?.programImages ?? data?.programImages[0].id); // 이전 img Id
         }
+        // else {
+        //   /** 이전이미지 없으면 이미지 추가 */
+        // }
       })
       .catch((err) => console.log(err));
   };
-  // console.log(prev);
+  // console.log(prev ?? prev?.programImages.length);
+  // console.log('아이디', prevImgId);
 
   //처음 렌더링 될 때 제목인풋에 포커즈
   useEffect(() => {
@@ -292,10 +294,9 @@ function ProgUpdate() {
     formData.append('location', location);
     formData.append('programDate', programDate);
     formData.append('minKind', minkind);
-    formData.append('programImageId', prevImgId);
 
-    /** 이전이미지가 있어서 base64로 인코딩된 경우 */
-    if (typeof picture === 'string') {
+    /** 이전이미지가 있어서 base64로 인코딩된 경우 - 이미지파일, 이미지id 추가*/
+    if (typeof picture === 'string' && picture.length > 0) {
       /** 미리보기때문에 img base64인코딩 문자열을 다시 => Blob 형식으로 변환 후 전달 */
       const byteString = window.atob((picture as string).split(',')[1]);
       const ab = new ArrayBuffer(byteString.length);
@@ -308,6 +309,7 @@ function ProgUpdate() {
       });
       // const file = new File([blob], 'image.png'); //이걸로 넣으면 안되서 일단 주석
       formData.append('imageFile', blob);
+      formData.append('programImageId', prevImgId);
     } else {
       formData.append('imageFile', picture);
     }

--- a/client/src/pages/ProgUpdate.tsx
+++ b/client/src/pages/ProgUpdate.tsx
@@ -3,6 +3,7 @@ import Layout from 'components/Layout';
 import React, { useState, useRef, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import ImgDeleteBtnSvg from '../images/ImgDeleteBtn.svg';
 
 const CreateContainer = styled.div`
   width: 100%;
@@ -153,6 +154,7 @@ const ImageInput = styled.input`
 `;
 
 const ImageLabel = styled.label`
+  position: relative;
   height: 200px;
   width: 100%;
   border: 1px solid #e2e6e8;
@@ -189,9 +191,13 @@ const AreaSelect = styled.select`
   display: flex;
   align-items: center;
 `;
-
-const AreaOption = styled.option`
-  margin-left: 5px;
+const ImgDeleteBtn = styled.button`
+  position: absolute;
+  z-index: 10;
+  top: -1rem;
+  right: -1rem;
+  border: none;
+  background-color: transparent;
 `;
 
 interface PrevProgramProps {
@@ -302,7 +308,6 @@ function ProgUpdate() {
     // for (let values of formData.values()) {
     //   console.log(values); // formData 객체의 정보 확인하는 법
     // }
-
     axios({
       method: 'patch',
       url: `${URL}/api/programs/${programId}`,
@@ -354,6 +359,11 @@ function ProgUpdate() {
     setPicture((e.target as any).files[0]);
     // @ts-ignore
     setImagePreview(window.URL.createObjectURL((e.target as any).files[0]));
+  };
+  const handelImgDeleteBtn = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setPicture('');
+    setImagePreview('');
   };
 
   return (
@@ -469,9 +479,14 @@ function ProgUpdate() {
                 우리 모임을 소개할 이미지를 첨부해주세요.
               </ImageLabel>
             ) : (
-              <ImageLabel htmlFor="file">
-                <img width="100%" height="100%" src={imagePreview}></img>
-              </ImageLabel>
+              <>
+                <ImageLabel htmlFor="file">
+                  <img width="100%" height="100%" src={imagePreview}></img>
+                  <ImgDeleteBtn type="button" onClick={handelImgDeleteBtn}>
+                    <img src={ImgDeleteBtnSvg} alt="delete" />
+                  </ImgDeleteBtn>
+                </ImageLabel>
+              </>
             )}
             <ImageInput
               id="file"

--- a/client/src/pages/ProgUpdate.tsx
+++ b/client/src/pages/ProgUpdate.tsx
@@ -253,37 +253,15 @@ function ProgUpdate() {
           );
           setPrevImgId(data.programImages[0].id); // 이전 img Id
         }
-        // else {
-        //   /** 이전이미지 없으면 이미지 추가 */
-        // }
       })
       .catch((err) => console.log(err));
   };
-
-  // if (prevImgId!) {
-  //   console.log('아이디', prevImgId ?? prevImgId!);
-  // }
 
   //처음 렌더링 될 때 제목인풋에 포커즈
   useEffect(() => {
     firstRef.current.focus();
     getProgram();
   }, []);
-
-  /*  const handleBaseForm = async (picture: string) => {
-    const byteString = window.atob(picture.split(',')[1]);
-    // Blob를 구성하기 위한 준비, 이 내용은 저도 잘 이해가 안가서 기술하지 않았습니다.
-    const ab = new ArrayBuffer(byteString.length);
-    const ia = new Uint8Array(ab);
-    for (let i = 0; i < byteString.length; i++) {
-      ia[i] = byteString.charCodeAt(i);
-    }
-    const blob = new Blob([ia], {
-      type: 'image/png',
-    });
-    const file = new File([blob], 'image.png');
-    return file;
-  }; */
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -311,10 +289,13 @@ function ProgUpdate() {
       });
       // const file = new File([blob], 'image.png'); //이걸로 넣으면 안되서 일단 주석
       formData.append('imageFile', blob);
-      if (prevImgId!) {
+      formData.append('programImageId', prevImgId);
+    } else {
+      /** 이전이미지 O 이미지 수정할때 - id전송 */
+      if (prevImgId !== null) {
         formData.append('programImageId', prevImgId);
       }
-    } else {
+      /** 이전이미지 X 이미지 추가할때 - 파일전송*/
       formData.append('imageFile', picture);
     }
 
@@ -329,7 +310,7 @@ function ProgUpdate() {
       data: formData,
     })
       .then((res) => {
-        console.log(res);
+        console.log(res.data);
         navigate(`/programs/${programId}`);
       })
       .catch((err) => console.log(err));

--- a/client/src/pages/ProgUpdate.tsx
+++ b/client/src/pages/ProgUpdate.tsx
@@ -320,7 +320,6 @@ function ProgUpdate() {
       data: formData,
     })
       .then((res) => {
-        console.log(res.data);
         navigate(`/programs/${programId}`);
       })
       .catch((err) => console.log(err));

--- a/client/src/pages/ProgUpdate.tsx
+++ b/client/src/pages/ProgUpdate.tsx
@@ -228,7 +228,7 @@ function ProgUpdate() {
   const [prev, setPrev] = useState<any>({});
   const [imagePreview, setImagePreview] = useState('');
   const [minkind, setMinKind] = useState<string>(`${prev && prev?.minKind}`);
-  const [prevImgId, setPrevImgId] = useState<any>();
+  const [prevImgId, setPrevImgId] = useState<any>(null);
 
   const { programId } = useParams();
   const navigate = useNavigate();
@@ -251,7 +251,7 @@ function ProgUpdate() {
           setImagePreview(
             `data:${data.programImages[0].contentType};base64,${data?.programImages[0].bytes}`
           );
-          setPrevImgId(data?.programImages ?? data?.programImages[0].id); // 이전 img Id
+          setPrevImgId(data.programImages[0].id); // 이전 img Id
         }
         // else {
         //   /** 이전이미지 없으면 이미지 추가 */
@@ -259,8 +259,10 @@ function ProgUpdate() {
       })
       .catch((err) => console.log(err));
   };
-  // console.log(prev ?? prev?.programImages.length);
-  // console.log('아이디', prevImgId);
+
+  // if (prevImgId!) {
+  //   console.log('아이디', prevImgId ?? prevImgId!);
+  // }
 
   //처음 렌더링 될 때 제목인풋에 포커즈
   useEffect(() => {
@@ -309,7 +311,9 @@ function ProgUpdate() {
       });
       // const file = new File([blob], 'image.png'); //이걸로 넣으면 안되서 일단 주석
       formData.append('imageFile', blob);
-      formData.append('programImageId', prevImgId);
+      if (prevImgId!) {
+        formData.append('programImageId', prevImgId);
+      }
     } else {
       formData.append('imageFile', picture);
     }

--- a/client/src/pages/SignUp.tsx
+++ b/client/src/pages/SignUp.tsx
@@ -37,7 +37,7 @@ const LoginText = styled.div`
 `;
 
 export default function SignUp() {
-  const URL = process.env.REACT_APP_DEV_URL; //민정님주소
+  const URL = process.env.REACT_APP_DEV_TWO_URL;
   const navigate = useNavigate();
   const {
     register,

--- a/client/src/pages/SignUp.tsx
+++ b/client/src/pages/SignUp.tsx
@@ -37,7 +37,7 @@ const LoginText = styled.div`
 `;
 
 export default function SignUp() {
-  const URL = process.env.REACT_APP_DEV_TWO_URL;
+  const URL = process.env.REACT_APP_DEV_URL;
   const navigate = useNavigate();
   const {
     register,

--- a/client/src/stores/store.ts
+++ b/client/src/stores/store.ts
@@ -1,12 +1,37 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
+import {
+  persistReducer,
+  FLUSH,
+  REHYDRATE,
+  PAUSE,
+  PERSIST,
+  PURGE,
+  REGISTER,
+} from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
 import searchReducer from './searchSlice';
 import userInfoSlice from './userInfoSlice';
 
+const rootReducer = combineReducers({
+  search: searchReducer,
+  userInfo: userInfoSlice,
+});
+
+const persistConfig = {
+  key: 'root',
+  storage,
+};
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
 const store = configureStore({
-  reducer: {
-    search: searchReducer,
-    userInfo: userInfoSlice,
-  },
+  reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: {
+        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+      },
+    }),
   devTools: process.env.REACT_APP_ENV !== 'production',
   //   preloadedState, // SSR 서버에서 init state있을 때
 });

--- a/client/src/stores/userInfoSlice.ts
+++ b/client/src/stores/userInfoSlice.ts
@@ -27,14 +27,18 @@ export const fetchUserInfo = createAsyncThunk(`GET/USERINFO`, async () => {
 interface UsersState {
   // user: UserInfo; // 타입 에러남
   users: any;
-  isLoggedId: boolean;
+  userId: number;
+  loginId: string;
+  isLoggedIn: boolean;
   loading: 'idle' | 'loading' | 'succeeded' | 'failed';
   error: any;
 }
 
 const initialState = {
   users: {},
-  isLoggedId: false,
+  userId: 0,
+  loginId: '',
+  isLoggedIn: false,
   loading: 'idle',
   error: null,
 } as UsersState;
@@ -43,15 +47,17 @@ export const userInfoSlice = createSlice({
   name: 'userInfo',
   initialState,
   reducers: {
-    getUserInfos(state, action: PayloadAction<any>) {
-      state.users = action.payload;
+    getUserId(state, action: PayloadAction<any>) {
+      state.userId = action.payload.id;
+      state.loginId = action.payload.loginId;
+      state.isLoggedIn = true;
     },
     loginUser(state, action) {
-      state.isLoggedId = true;
+      state.isLoggedIn = true;
       state.users = action.payload;
     },
     logoutUser(state) {
-      state.isLoggedId = false;
+      state.isLoggedIn = false;
       state.users = {};
     },
   },
@@ -59,26 +65,26 @@ export const userInfoSlice = createSlice({
     builder
       .addCase(fetchUserInfo.pending, (state) => {
         state.loading = 'loading';
-        state.isLoggedId = false;
+        state.isLoggedIn = false;
       })
       .addCase(fetchUserInfo.fulfilled, (state, action) => {
         state.loading = 'succeeded';
-        state.isLoggedId = true;
+        state.isLoggedIn = true;
         state.users = action.payload;
         state.error = '';
       })
       .addCase(fetchUserInfo.rejected, (state, action) => {
         state.loading = 'failed';
-        state.isLoggedId = false;
+        state.isLoggedIn = false;
         state.users = {};
         state.error = action.error.message;
       });
   },
 });
 
-export const getisLoggedId = (state: any) => state.userInfo.isLoggedId;
+export const getisLoggedIn = (state: any) => state.userInfo.isLoggedIn;
 export const getUserData = (state: any) => state.userInfo.users;
 export const getUserError = (state: any) => state.userInfo.error;
 
-export const { getUserInfos, loginUser, logoutUser } = userInfoSlice.actions;
+export const { getUserId, loginUser, logoutUser } = userInfoSlice.actions;
 export default userInfoSlice.reducer;

--- a/client/src/stores/userInfoSlice.ts
+++ b/client/src/stores/userInfoSlice.ts
@@ -3,17 +3,16 @@ import axios from 'axios';
 
 const URL = process.env.REACT_APP_DEV_URL;
 
-export const fetchUserInfo = createAsyncThunk(
-  `GET/USERINFO`,
-  async (id: number, thunkApi) => {
-    try {
-      const response = await axios.get(`${URL}/api/users/${id}`);
-      return response.data;
-    } catch (err) {
-      return thunkApi.rejectWithValue(err);
-    }
+export const fetchUserInfo = createAsyncThunk(`GET/USERINFO`, async () => {
+  try {
+    const response = await axios.get(`${URL}/api/users/mypage`);
+    console.log('회원정보조회다!!', response.data);
+    return response.data;
+  } catch (err) {
+    return console.log(err);
+    //   return thunkApi.rejectWithValue(err);
   }
-);
+});
 
 /* interface UserInfo {
   id: number;

--- a/client/src/utils/parseJwt.ts
+++ b/client/src/utils/parseJwt.ts
@@ -1,0 +1,24 @@
+import { getLocalStorage } from 'apis/localStorage';
+
+const accessToken = getLocalStorage('access_token');
+const refreshToken = getLocalStorage('refresh_token');
+
+/** JWT 디코딩하여 exp, id, loginId, seb 확인 */
+export const parseJwt = (token: string | null) => {
+  if (token) return JSON.parse(window.atob(token.split('.')[1]));
+};
+
+/** 토큰 유효기간 */
+export const AuthVerify = () => {
+  const decodedAccess = parseJwt(accessToken);
+  const decodedRefresh = parseJwt(refreshToken);
+  //   console.log(decodedAccess, decodedRefresh); // 해부된 토큰내부 확인
+
+  if (decodedAccess.exp * 1000 < Date.now()) {
+    return 'Access Token Expired';
+  }
+  if (decodedRefresh.exp * 1000 < Date.now()) {
+    return 'Refresh Token Expired';
+  }
+  return true;
+};


### PR DESCRIPTION
## 프로그램 리스트 -Main
- api 수정
- Img 처리 
- 모집중 - 페이지네이션 적용
## 프로그램 수정
- 입력창들 수정안해도 이전 상태값 채워서 요청하게 수정
- 삭제버튼 누르면 삭제됨 - 삭제svg추가
## Redux-persist
- 사용 이유 : 새로고침 시 RTK가 리셋되는 것을 막기 위해 사용
- 새로고침해도 전역상태에 유저정보가 남아있음
- 기본설정 완료 - store.ts, index.tsx
## 헤더 분기
- 전역상태 isLoggedIn으로 로그인/비로그인 분기
## Logout
- 로그인 후 헤더 프로필에 있는 로그아웃 누르면 RTK와 localStorage에 유저정보 모두 삭제됨


# 특이사항
- 로그인여부 전역상태명 getisLoggedId => getisLoggedIn으로 이름변경
  ` const 변수명 = useAppSelector(getisLoggedIn); ` - 이렇게 사용하시면 됩니다.
- redux-persist 설치해서 **pull 받으면 npm i** 해야 합니다
