### PR TITLE
[BE] fix : doFilterInternal, successfulAuthentication, SecurityFilterChain, AuthDetails

### DIFF
--- a/server/src/main/java/com/codestates/team5/dailyclub/config/SecurityConfig.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.codestates.team5.dailyclub.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -64,7 +65,9 @@ public class SecurityConfig {
                 .accessDeniedHandler(jwtAccessDeniedHandler)
                 .and()
                 .authorizeRequests()
-//                .antMatchers("/api/mypages/**").access("hasRole('ADMIN')")
+                .antMatchers(HttpMethod.POST, "/api/programs/**").access("hasRole('USER')")
+                .antMatchers(HttpMethod.PATCH,"/api/programs/**").access("hasRole('USER')")
+                .antMatchers(HttpMethod.DELETE,"/api/programs/**").access("hasRole('USER')")
                 .anyRequest().permitAll()
                 .and()
                 .logout()

--- a/server/src/main/java/com/codestates/team5/dailyclub/jwt/AuthDetails.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/jwt/AuthDetails.java
@@ -12,11 +12,12 @@ import java.util.Collection;
 public class AuthDetails implements UserDetails {
     private final User user;
 
+    public long getUserId() { return  user.getId(); }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> authorities = new ArrayList<>();
-        authorities.add(() -> String.valueOf(user.getRole()));
+        authorities.add(() -> String.valueOf(user.getRole().getRole()));
         return authorities;
     }
 

--- a/server/src/main/java/com/codestates/team5/dailyclub/jwt/filter/JwtAuthenticationFilter.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/jwt/filter/JwtAuthenticationFilter.java
@@ -55,7 +55,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         logger.info(("로그인 성공 유저 처리"));
         String accessToken = tokenProvider.createAccessToken(authentication);
         String refreshToken = tokenProvider.renewalRefreshToken(authentication);
-        response.addHeader("Authorization", "Bearer" + accessToken);
-        response.addHeader("Refresh", "Bearer" + refreshToken);
+        response.addHeader("Authorization", "Bearer " + accessToken);
+        response.addHeader("Refresh", "Bearer " + refreshToken);
     }
 }


### PR DESCRIPTION
doFilterInternal 에서 헤더에 refreshToken이 오면 accessToken을 재발급 해서 보내도록 수정하였습니다.
successfulAuthentication에 Bearer입력이 잘못 되어있어 수정하였습니다.
SecurityFilterChain에 Role 확인 부분을 HttpMethod별로 구분하였습니다.
AuthDetails에 userId를 가지고 올 수 있는 getUserId 추가 하였으며 getAuthorities 에 getRole부분 수정했습니다.