### PR TITLE
[FE] feat: new access토큰으로 교체, 회원조회 api 수정, theme 파일분리

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,16 +13,12 @@ import NoticeDetail from 'pages/NoticeDetail';
 import NoticeCreate from 'pages/NoticeCreate';
 import ProgDetail from 'pages/ProgDetail';
 import ProgUpdate from 'pages/ProgUpdate';
+import { theme } from 'theme';
 
 const App: React.FC = () => {
   return (
     <div className="wrap">
-      <ThemeProvider
-        theme={{
-          lightGrey: '#e2e6e8',
-          accent: '#38d9a9',
-        }}
-      >
+      <ThemeProvider theme={theme}>
         <GlobalStyles />
         <BrowserRouter>
           <Header />

--- a/client/src/apis/api.ts
+++ b/client/src/apis/api.ts
@@ -1,37 +1,15 @@
-import axios, { AxiosRequestConfig } from 'axios';
-import { getLocalStorage } from './localStorage';
-
-/** 기본 api 인스턴스 */
-const BaseInstance = axios.create({
-  // baseURL: process.env.REACT_APP_DEV_TWO_URL,
-  baseURL: process.env.REACT_APP_DEV_URL,
-});
-
-/** 인증 필요한 api = 인스턴스 생성 후, interceptor에서 사용자인증(헤더담는) 작업 */
-const authInstance = axios.create({
-  baseURL: process.env.REACT_APP_DEV_URL,
-});
-authInstance.interceptors.request.use(
-  (config: AxiosRequestConfig): AxiosRequestConfig => {
-    if (!config.headers!.Authorization === undefined || null) {
-      const token = getLocalStorage('access_token');
-      if (token) config.headers!.Authorization = `Bearer ${token}`;
-    }
-    return config;
-  },
-  (error) => Promise.reject(error)
-);
+import AuthInstance, { BaseInstance } from './axiosConfig';
 
 export const API = {
   // User
   login: <T>(data: T) => {
-    return authInstance({ method: 'POST', url: `/login`, data });
+    return BaseInstance({ method: 'POST', url: `/login`, data });
   },
   getUserInfo: (userId: number) => {
-    return authInstance({ method: 'GET', url: `/api/users/${userId}` });
+    return AuthInstance({ method: 'GET', url: `/api/users/${userId}` });
   },
   editUserInfo: <D>(userId: number, data: D) => {
-    return authInstance({
+    return AuthInstance({
       method: 'PUT',
       url: `/api/users/${userId}`,
       data,
@@ -46,7 +24,7 @@ export const API = {
     return BaseInstance({ method: 'GET', url: `/api/programs/${programId}` });
   },
   createProgram: <T>(data: T) => {
-    return authInstance({
+    return AuthInstance({
       method: 'POST',
       url: `/api/programs`,
       data,
@@ -54,7 +32,7 @@ export const API = {
     });
   },
   updateProgram: <D>(programId: number, data: D) => {
-    return authInstance({
+    return AuthInstance({
       method: 'PUT',
       url: `/api/programs/${programId}`,
       data,
@@ -62,6 +40,6 @@ export const API = {
     });
   },
   deleteProgram: <I>(programId: I) => {
-    return authInstance({ method: 'DELETE', url: `programs/${programId}` });
+    return AuthInstance({ method: 'DELETE', url: `programs/${programId}` });
   },
 };

--- a/client/src/apis/axiosConfig.ts
+++ b/client/src/apis/axiosConfig.ts
@@ -58,7 +58,7 @@ axios.interceptors.response.use(
     //   authorization: `${newAccessToken}`, //택2
     // };
     // }
-    // return response; // 택1
+    return response; // 택1
     // return await axios(response.config); //택2
   },
   (error) => {

--- a/client/src/apis/axiosConfig.ts
+++ b/client/src/apis/axiosConfig.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosRequestConfig } from 'axios';
-import { ACCESS_EXP_MESSAGE, CheckJWTExp } from 'utils/parseJwt';
+import { ACCESS_EXP_MESSAGE, CheckJWTExp } from 'utils/CheckJwtExp';
 import { getLocalStorage } from './localStorage';
 
 axios.defaults.withCredentials = true;

--- a/client/src/apis/axiosConfig.ts
+++ b/client/src/apis/axiosConfig.ts
@@ -1,0 +1,62 @@
+import axios, { AxiosRequestConfig } from 'axios';
+import { ACCESS_EXP_MESSAGE, CheckJWTExp } from 'utils/parseJwt';
+import { getLocalStorage } from './localStorage';
+
+axios.defaults.withCredentials = true;
+
+/** 기본 api 인스턴스 */
+export const BaseInstance = axios.create({
+  baseURL: process.env.REACT_APP_DEV_URL,
+});
+
+/** 인증 필요한 api = 인스턴스 생성 후, interceptor에서 사용자인증(헤더담는) 작업 */
+const AuthInstance = axios.create({
+  baseURL: process.env.REACT_APP_DEV_URL,
+  // baseURL: process.env.REACT_APP_DEV_URL,
+});
+
+/** 1. 요청 전 access토큰있는데 만료되면 refresh토큰도 헤더담아서 요청보내기 */
+axios.interceptors.request.use(
+  (config: AxiosRequestConfig) => {
+    const accessToken = getLocalStorage('access_token');
+    const refreshToken = getLocalStorage('refresh_token');
+    if (accessToken) {
+      /** 2. access토큰 있으면 만료됐는지 체크 */
+      if (CheckJWTExp() === ACCESS_EXP_MESSAGE) {
+        // console.log('만료됨! refresh 토큰 담기');    ////
+
+        // config.headers = {
+        //   authorization: `${accessToken}`,
+        //   refresh: `${refreshToken}`,
+        // };
+        config.headers!.Authorization = `${accessToken}`;
+        config.headers!.Refresh = `${refreshToken}`;
+      } else {
+        config.headers!.Authorization = `${accessToken}`;
+      }
+    }
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+/** 응답으로 access토큰받으면 갈아끼기 */
+axios.interceptors.response.use(
+  (response) => {
+    // 응답 200이면 성공 직전 호출 .then()으로 이어짐
+    // console.log('서버응답헤더! :', response.headers);    ////
+    // if (response.headers.access) {
+    //   const newAccessToken = response.data.access
+    //   removeLocalStorage('access_token'); // 만료된 access토큰 삭제
+    //   config.headers!.Authorization = `${accessToken}`;
+    // }
+    return response;
+  },
+  (error) => {
+    //응답 200 아닌 경우 - 디버깅
+    console.log(error);
+    return Promise.reject(error);
+  }
+);
+
+export default AuthInstance;

--- a/client/src/apis/axiosConfig.ts
+++ b/client/src/apis/axiosConfig.ts
@@ -1,6 +1,10 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import { ACCESS_EXP_MESSAGE, CheckJWTExp } from 'utils/CheckJwtExp';
-import { getLocalStorage } from './localStorage';
+import {
+  getLocalStorage,
+  removeLocalStorage,
+  setLocalStorage,
+} from './localStorage';
 
 axios.defaults.withCredentials = true;
 
@@ -48,7 +52,8 @@ axios.interceptors.response.use(
     // if (response.headers.access) {
     //   const newAccessToken = response.data.access
     //   removeLocalStorage('access_token'); // 만료된 access토큰 삭제
-    //   config.headers!.Authorization = `${accessToken}`;
+    //   setLocalStorage('access_token', newAccessToken); // 새걸로 교체
+    //   config.headers!.Authorization = `${newAccessToken}`;
     // }
     return response;
   },

--- a/client/src/apis/axiosConfig.ts
+++ b/client/src/apis/axiosConfig.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig } from 'axios';
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { ACCESS_EXP_MESSAGE, CheckJWTExp } from 'utils/CheckJwtExp';
 import {
   getLocalStorage,
@@ -46,16 +46,20 @@ axios.interceptors.request.use(
 
 /** 응답으로 access토큰받으면 갈아끼기 */
 axios.interceptors.response.use(
-  (response) => {
+  async (response: AxiosResponse) => {
     // 응답 200이면 성공 직전 호출 .then()으로 이어짐
     // console.log('서버응답헤더! :', response.headers);    ////
     // if (response.headers.access) {
     //   const newAccessToken = response.data.access
     //   removeLocalStorage('access_token'); // 만료된 access토큰 삭제
     //   setLocalStorage('access_token', newAccessToken); // 새걸로 교체
-    //   config.headers!.Authorization = `${newAccessToken}`;
+    //   config.headers!.Authorization = `${newAccessToken}`; // 택1
+    // response.config.headers = {
+    //   authorization: `${newAccessToken}`, //택2
+    // };
     // }
-    return response;
+    // return response; // 택1
+    // return await axios(response.config); //택2
   },
   (error) => {
     //응답 200 아닌 경우 - 디버깅

--- a/client/src/apis/axiosConfig.ts
+++ b/client/src/apis/axiosConfig.ts
@@ -16,10 +16,9 @@ export const BaseInstance = axios.create({
 /** 인증 필요한 api = 인스턴스 생성 후, interceptor에서 사용자인증(헤더담는) 작업 */
 const AuthInstance = axios.create({
   baseURL: process.env.REACT_APP_DEV_URL,
-  // baseURL: process.env.REACT_APP_DEV_URL,
 });
 
-/** 1. 요청 전 access토큰있는데 만료되면 refresh토큰도 헤더담아서 요청보내기 */
+/** 1. 요청 전 - access토큰있는데 만료되면 refresh토큰도 헤더담아서 요청보내기 */
 axios.interceptors.request.use(
   (config: AxiosRequestConfig) => {
     const accessToken = getLocalStorage('access_token');
@@ -27,12 +26,8 @@ axios.interceptors.request.use(
     if (accessToken) {
       /** 2. access토큰 있으면 만료됐는지 체크 */
       if (CheckJWTExp() === ACCESS_EXP_MESSAGE) {
-        // console.log('만료됨! refresh 토큰 담기');    ////
-
-        // config.headers = {
-        //   authorization: `${accessToken}`,
-        //   refresh: `${refreshToken}`,
-        // };
+        /** 3. 만료되면 만료된 access, refresh 같이 헤더 담아서 요청 */
+        // console.log('만료됨! refresh 토큰 담기'); ////
         config.headers!.Authorization = `${accessToken}`;
         config.headers!.Refresh = `${refreshToken}`;
       } else {
@@ -44,26 +39,23 @@ axios.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
-/** 응답으로 access토큰받으면 갈아끼기 */
+/** 4. 응답 전 - 새 access토큰받으면 갈아끼기 */
 axios.interceptors.response.use(
   async (response: AxiosResponse) => {
-    // 응답 200이면 성공 직전 호출 .then()으로 이어짐
-    // console.log('서버응답헤더! :', response.headers);    ////
-    // if (response.headers.access) {
-    //   const newAccessToken = response.data.access
-    //   removeLocalStorage('access_token'); // 만료된 access토큰 삭제
-    //   setLocalStorage('access_token', newAccessToken); // 새걸로 교체
-    //   config.headers!.Authorization = `${newAccessToken}`; // 택1
-    // response.config.headers = {
-    //   authorization: `${newAccessToken}`, //택2
-    // };
-    // }
-    return response; // 택1
-    // return await axios(response.config); //택2
+    if (response.headers.authorization) {
+      // console.log('헤더 :', response.headers);
+      const newAccessToken = response?.headers?.authorization;
+      removeLocalStorage('access_token'); // 만료된 access토큰 삭제
+      setLocalStorage('access_token', newAccessToken); // 새걸로 교체
+      response.config.headers = {
+        authorization: `${newAccessToken}`,
+      };
+    }
+    return response;
   },
   (error) => {
     //응답 200 아닌 경우 - 디버깅
-    console.log(error);
+    // console.log(error);
     return Promise.reject(error);
   }
 );

--- a/client/src/components/AreaFilter.tsx
+++ b/client/src/components/AreaFilter.tsx
@@ -69,7 +69,8 @@ function AreaFilter({ setAreaSelected }: AreaProps) {
   const areaList: string[] = [
     '지역',
     '서울',
-    '경기/강원',
+    '경기',
+    '강원',
     '인천',
     '대전/충청',
     '대구/경북',

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -197,18 +197,15 @@ export default function Header() {
   const handelSearchSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     dispatch(searchActions.getKeyword(InputValue)); //헤더 input값 전역상태에 저장
-  };
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      navigate('/'); // 엔터 시 질문목록 메인페이지로 이동
-      // setInputValue(''); // input창만 비우고 싶은데 전달할 전역상태까지 비워져버림
-    }
+    navigate('/'); // 엔터 시 질문목록 메인페이지로 이동
+    setInputValue(''); // input창 초기화
   };
   const handleLogoutBtn = () => {
     dispatch(logoutUser());
     removeLocalStorage('access_token');
     removeLocalStorage('refresh_token');
     setIsOpened(false);
+    navigate('/');
   };
 
   return (
@@ -231,7 +228,6 @@ export default function Header() {
               </SearchBtn>
               <SearchInput
                 onChange={(e) => setInputValue(e.target.value)}
-                onKeyPress={handleKeyPress}
                 value={InputValue}
                 placeholder="프로그램 / 모임을 검색해보세요"
               />

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -259,7 +259,7 @@ export default function Header() {
                 <Icon>
                   <ProfileBtn onClick={() => setIsOpened(!isopened)}>
                     <img
-                      src={users ? null : Profile}
+                      src={users?.picture ? null : Profile}
                       alt="profile"
                       style={{ height: 25, width: 25 }}
                     />
@@ -280,7 +280,7 @@ export default function Header() {
                 <Link to="/mypage">
                   <UserProfileImg>
                     <img
-                      src={users ? null : Profile}
+                      src={users?.picture ? null : Profile}
                       alt="userImg"
                       style={{
                         height: 70,

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -287,7 +287,7 @@ export default function Header() {
                     />
                   </UserProfileImg>
                 </Link>
-                <UserNickName>닉네임</UserNickName>
+                <UserNickName>{users?.nickname}</UserNickName>
                 <Link to="/mypage">
                   <MyPageBtn>마이페이지</MyPageBtn>
                 </Link>

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -72,11 +72,11 @@ export default function Login() {
           //JWT디코딩해서 userId, loginId 등 전역상태
           const decodedAccess = parseJwt(accessToken);
           dispatch(getUserId(decodedAccess)); //JWT 내용 전역상태
+          dispatch(fetchUserInfo(decodedAccess.id)); // 로그인 후, 로그인한 유저정보조회
           // console.log('토큰해부', decodedAccess);
         }
       })
       .then(() => {
-        dispatch(fetchUserInfo()); // 로그인 후, 로그인한 유저정보조회
         // dispatch(fetchUserInfo(decodedAccess.id));//유저조회 thunk 전역상태에 저장
       })
       .catch((error) => console.log(error));

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -3,7 +3,7 @@ import { SubmitHandler, useForm } from 'react-hook-form';
 import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { LoginVal } from 'types/user';
-// import { API } from 'apis/api';
+import { API } from 'apis/api';
 import { setLocalStorage } from 'apis/localStorage';
 import Layout from 'components/Layout';
 import OauthBtn from 'components/OAuth/OauthBtn';
@@ -52,42 +52,26 @@ export default function Login() {
   } = useForm<LoginVal>();
 
   const handleLoginSubmit: SubmitHandler<LoginVal> = (data) => {
-    // API.login(data); // test해봐야 함
-    axios.defaults.withCredentials = true; // withCredentials 전역 설정
-    axios
-      .post(`${URL}/login`, data)
+    API.login(data)
       .then((res) => {
-        if (res.status === 200) {
-          let accessToken = res.headers.authorization;
-          let refreshToken = res.headers.refresh;
-          console.log('access 토큰 :', accessToken);
-          console.log('refresh 토큰 :', refreshToken);
-          setLocalStorage('access_token', accessToken);
-          setLocalStorage('refresh_token', refreshToken);
-          // API 요청마다 헤더에 access토큰 담아서 요청보내는 설정
-          axios.defaults.headers.common['Authorization'] = `${accessToken}`;
-          // axios.defaults.headers.common['Refresh'] = `${refreshToken}`;
-          navigate('/');
+        let accessToken = res.headers.authorization;
+        let refreshToken = res.headers.refresh;
+        console.log('access 토큰 :', accessToken);
+        console.log('refresh 토큰 :', refreshToken);
+        setLocalStorage('access_token', accessToken);
+        setLocalStorage('refresh_token', refreshToken);
+        // API 요청마다 헤더에 access토큰 담아서 요청보내는 설정
+        axios.defaults.headers.common['Authorization'] = `${accessToken}`;
+        // axios.defaults.headers.common['Refresh'] = `${refreshToken}`;
+        navigate('/');
 
-          //JWT디코딩해서 userId, loginId 등 전역상태
-          const decodedAccess = parseJwt(accessToken);
-          dispatch(getUserId(decodedAccess)); //JWT 내용 전역상태
-          dispatch(fetchUserInfo(decodedAccess.id)); // 로그인 후, 로그인한 유저정보조회
-          // console.log('토큰해부', decodedAccess);
-        }
-      })
-      .then(() => {
-        // dispatch(fetchUserInfo(decodedAccess.id));//유저조회 thunk 전역상태에 저장
+        //JWT디코딩해서 userId, loginId 등 전역상태
+        const decodedAccess = parseJwt(accessToken);
+        dispatch(getUserId(decodedAccess)); //JWT 내용 전역상태
+        dispatch(fetchUserInfo(decodedAccess.id)); // 로그인유저정보 전역상태에 저장
+        // console.log('토큰해부', decodedAccess);
       })
       .catch((error) => console.log(error));
-
-    // localStorage.setItem('Authorization', jwtToken);
-    // const accessToken = JSON.parse(localStorage.getItem('accessToken') as string);
-    // if (accessToken) {
-    //   axios.defaults.headers.common[
-    //     'Authorization'
-    //   ] = `Bearer ${accessToken}`;
-    // }
   };
 
   return (

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -10,7 +10,12 @@ import LevelPercent from 'components/LevelPercent';
 import ProgressBar from 'components/ProgressBar';
 import { Link } from 'react-router-dom';
 import { useAppSelector } from 'stores/hooks';
-import { getisLoggedIn, getUserData, getUserError } from 'stores/userInfoSlice';
+import {
+  getisLoggedIn,
+  getUserData,
+  getUserError,
+  getUserId,
+} from 'stores/userInfoSlice';
 import BasicImg from '../images/BasicImg.jpg';
 import Pagination from 'pagination/Pagination';
 import { ProgramDetailVal } from 'types/programs';
@@ -152,15 +157,19 @@ export default function Main() {
 
   // console.log(searchKeyword); // input값 전역상태에서 가져온거 확인용
 
-  /** 유저 전역상태 전체 - users, isLoggedId, loading, error  */
+  /** 유저 전역상태 전체 - users, isLoggedIn, loading, error  */
   const loginUserInfo = useAppSelector((state) => state.userInfo);
-  // console.log('유저 전역정보: ', loginUserInfo ?? loginUserInfo); // 확인용
+  console.log('유저 전역정보: ', loginUserInfo ?? loginUserInfo); // 확인용
 
-  /** 유저 전역상태 1개씩 - isLoggedId, users, error */
-  const isLoggedId = useAppSelector(getisLoggedIn); // 로그인여부
+  const { users, loading, loginId, userId } = useAppSelector(
+    (state) => state.userInfo
+  );
+
+  /** 유저 전역상태 1개씩 - isLoggedIn, users, error */
+  const isLoggedIn = useAppSelector(getisLoggedIn); // 로그인여부
   const userData = useAppSelector(getUserData); // 유저정보
   const userError = useAppSelector(getUserError); // 에러내용
-  // console.log('유저 전역상태: ', isLoggedId, userData, userError); // 확인 후 주석해제하면 됩니다
+  // console.log('유저 전역상태: ', isLoggedIn, userData, userError); // 확인 후 주석해제하면 됩니다
 
   /** 필터 조회api - 키워드,지역,날짜,친절도*/
   useEffect(() => {

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -14,6 +14,7 @@ import { getisLoggedIn, getUserData, getUserError } from 'stores/userInfoSlice';
 import BasicImg from '../images/BasicImg.jpg';
 import Pagination from 'pagination/Pagination';
 import { ProgramDetailVal } from 'types/programs';
+import qs from 'qs';
 
 const WrapContainer = styled.div`
   margin-bottom: 5rem;
@@ -149,6 +150,7 @@ export default function Main() {
   const [programs, setPrograms] = useState<Array<ProgramDetailVal>>([]);
   const [pageList, setPageList] = useState();
   const [page, setPage] = useState<number>(1);
+  const [programStatus, setProgramStatus] = useState('모집중');
 
   // console.log(searchKeyword); // input값 전역상태에서 가져온거 확인용
 
@@ -162,14 +164,25 @@ export default function Main() {
   const userError = useAppSelector(getUserError); // 에러내용
   // console.log('유저 전역상태: ', isLoggedIn, userData, userError); // 확인 후 주석해제하면 됩니다
 
+  const REQ_PARAMS = {
+    keyword: searchKeyword,
+    location: areaSelected,
+    minKind: rangeValue,
+    programDate: dateSelected,
+    programStatus: programStatus,
+  };
+
   /** 필터 조회api - 키워드,지역,날짜,친절도*/
   useEffect(() => {
     const getProgramList = async () => {
       await axios
+        // .get(`${URL}/api/programs?page=${page}&size=10`, {
+        //   params: REQ_PARAMS,
+        // })
         .get(`${URL}/api/programs?page=${page}&size=10`)
         // .get(
         //   `${URL}/api/programs?page=1&size=10
-        // &keyword=${searchKeyword}&location=${areaSelected}&minKind=${rangeValue}&programDate=${dateSelected}&programStatus='모집중'`
+        // &keyword=${searchKeyword}&location=${areaSelected}&minKind=${rangeValue}&programDate=${dateSelected}&programStatus=${programStatus}`
         // )
         .then(({ data }) => {
           setPrograms(data?.data);

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -169,7 +169,7 @@ export default function Main() {
         .get(`${URL}/api/programs?page=${page}&size=10`)
         // .get(
         //   `${URL}/api/programs?page=1&size=10
-        // &keyword=${searchKeyword}&location=${areaSelected}&minKind=${rangeValue}&programDate=${dateSelected}&programStatus=POSSIBLE`
+        // &keyword=${searchKeyword}&location=${areaSelected}&minKind=${rangeValue}&programDate=${dateSelected}&programStatus='모집중'`
         // )
         .then(({ data }) => {
           setPrograms(data?.data);
@@ -253,6 +253,7 @@ export default function Main() {
                           borderRadius: '5px',
                         }}
                         alt="program Image"
+                        loading="lazy"
                       />
                       <ProgBookmark>
                         <img src={Bookmark} alt="bookmark" />
@@ -306,6 +307,7 @@ export default function Main() {
                         borderRadius: '5px',
                       }}
                       alt="program Image"
+                      loading="lazy"
                     />
                     <ProgBookmark>
                       <img src={Bookmark} alt="bookmark" />

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -14,7 +14,6 @@ import { getisLoggedIn, getUserData, getUserError } from 'stores/userInfoSlice';
 import BasicImg from '../images/BasicImg.jpg';
 import Pagination from 'pagination/Pagination';
 import { ProgramDetailVal } from 'types/programs';
-import qs from 'qs';
 
 const WrapContainer = styled.div`
   margin-bottom: 5rem;
@@ -65,11 +64,13 @@ const WrapLevel = styled.div`
   border: 1px solid lightGrey;
   border-radius: 5px;
   background-color: white;
+  cursor: default;
 `;
 const WrapLevelRangeInput = styled.input`
   width: 80%;
   height: 3px;
   background: #ff5924;
+  cursor: pointer;
 `;
 const RangeValue = styled.div`
   margin: 1rem;
@@ -151,6 +152,7 @@ export default function Main() {
   const [pageList, setPageList] = useState();
   const [page, setPage] = useState<number>(1);
   const [programStatus, setProgramStatus] = useState('모집중');
+  const [minKindVal, setMinKindVal] = useState('');
 
   // console.log(searchKeyword); // input값 전역상태에서 가져온거 확인용
 
@@ -167,7 +169,7 @@ export default function Main() {
   const REQ_PARAMS = {
     keyword: searchKeyword,
     location: areaSelected,
-    minKind: rangeValue,
+    minKind: minKindVal,
     programDate: dateSelected,
     programStatus: programStatus,
   };
@@ -182,7 +184,7 @@ export default function Main() {
         .get(`${URL}/api/programs?page=${page}&size=10`)
         // .get(
         //   `${URL}/api/programs?page=1&size=10
-        // &keyword=${searchKeyword}&location=${areaSelected}&minKind=${rangeValue}&programDate=${dateSelected}&programStatus=${programStatus}`
+        // &keyword=${searchKeyword}&location=${areaSelected}&minKind=${minKindVal}&programDate=${dateSelected}&programStatus=${programStatus}`
         // )
         .then(({ data }) => {
           setPrograms(data?.data);
@@ -209,8 +211,11 @@ export default function Main() {
               onChange={(e) => setDateSelected(e.target.value)}
               onFocus={(e) => (e.target.type = 'date')}
             />
-            <LevelRange onClick={() => setLevelOpened(!levelOpened)}>
-              친절도 &nbsp;{rangeValue}%
+            <LevelRange
+              onClick={() => setLevelOpened(!levelOpened)}
+              onMouseUp={() => setMinKindVal(rangeValue)}
+            >
+              친절도 &nbsp;{minKindVal}%
               <img src={QuestionMark} alt="question mark" />
               <img src={DownArrow} alt="down arrow" />
               {levelOpened ? (
@@ -227,6 +232,7 @@ export default function Main() {
                     max={100}
                     step={1}
                     onChange={(e) => setRangeValue(e.target.value)}
+                    defaultValue={minKindVal}
                   />
                   <RangeValue>{rangeValue}%</RangeValue>
                 </WrapLevel>

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -9,11 +9,12 @@ import DownArrow from '../images/DownArrow.svg';
 import LevelPercent from 'components/LevelPercent';
 import ProgressBar from 'components/ProgressBar';
 import { Link } from 'react-router-dom';
-import { useAppSelector } from 'stores/hooks';
+import { useAppDispatch, useAppSelector } from 'stores/hooks';
 import { getisLoggedIn, getUserData, getUserError } from 'stores/userInfoSlice';
 import BasicImg from '../images/BasicImg.jpg';
 import Pagination from 'pagination/Pagination';
 import { ProgramDetailVal } from 'types/programs';
+import { searchActions } from 'stores/searchSlice';
 
 const WrapContainer = styled.div`
   margin-bottom: 5rem;
@@ -153,6 +154,7 @@ export default function Main() {
   const [page, setPage] = useState<number>(1);
   const [programStatus, setProgramStatus] = useState('모집중');
   const [minKindVal, setMinKindVal] = useState('');
+  const dispatch = useAppDispatch();
 
   // console.log(searchKeyword); // input값 전역상태에서 가져온거 확인용
 
@@ -189,6 +191,7 @@ export default function Main() {
         .then(({ data }) => {
           setPrograms(data?.data);
           setPageList(data?.pageInfo);
+          dispatch(searchActions.getKeyword(''));
         })
         .catch((err) => console.log(err.message));
     };

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -10,12 +10,7 @@ import LevelPercent from 'components/LevelPercent';
 import ProgressBar from 'components/ProgressBar';
 import { Link } from 'react-router-dom';
 import { useAppSelector } from 'stores/hooks';
-import {
-  getisLoggedIn,
-  getUserData,
-  getUserError,
-  getUserId,
-} from 'stores/userInfoSlice';
+import { getisLoggedIn, getUserData, getUserError } from 'stores/userInfoSlice';
 import BasicImg from '../images/BasicImg.jpg';
 import Pagination from 'pagination/Pagination';
 import { ProgramDetailVal } from 'types/programs';
@@ -159,11 +154,7 @@ export default function Main() {
 
   /** 유저 전역상태 전체 - users, isLoggedIn, loading, error  */
   const loginUserInfo = useAppSelector((state) => state.userInfo);
-  console.log('유저 전역정보: ', loginUserInfo ?? loginUserInfo); // 확인용
-
-  const { users, loading, loginId, userId } = useAppSelector(
-    (state) => state.userInfo
-  );
+  // console.log('유저 전역정보: ', loginUserInfo ?? loginUserInfo); // 확인용
 
   /** 유저 전역상태 1개씩 - isLoggedIn, users, error */
   const isLoggedIn = useAppSelector(getisLoggedIn); // 로그인여부

--- a/client/src/stores/userInfoSlice.ts
+++ b/client/src/stores/userInfoSlice.ts
@@ -4,24 +4,27 @@ import axios from 'axios';
 
 const URL = process.env.REACT_APP_DEV_URL;
 
-export const fetchUserInfo = createAsyncThunk(`GET/USERINFO`, async () => {
-  try {
-    const response = await axios.get(`${URL}/api/users/mypage`);
-    console.log('회원정보조회다!!', response.data);
+export const fetchUserInfo = createAsyncThunk(
+  `GET/USERINFO`,
+  async (id: number, thunkApi) => {
+    try {
+      const response = await axios.get(`${URL}/api/users/${id}`);
+      console.log('회원정보조회다!!', response.data);
 
-    /** access token 만료시 헤더에 refresh토큰 담아서 get 요청 -백엔드작업중 */
-    if (response.data === 'Access Token Expired') {
-      removeLocalStorage('access_token'); // 만료된 access토큰 삭제
-      const refreshToken = getLocalStorage('refresh_token');
-      axios.defaults.headers.common['Refresh'] = `${refreshToken}`;
-      // 새로 발급받은 access토큰으로 교체
+      /** access token 만료시 헤더에 refresh토큰 담아서 get 요청 -백엔드작업중 */
+      if (response.data === 'Access Token Expired') {
+        removeLocalStorage('access_token'); // 만료된 access토큰 삭제
+        const refreshToken = getLocalStorage('refresh_token');
+        axios.defaults.headers.common['Refresh'] = `${refreshToken}`;
+        // 새로 발급받은 access토큰으로 교체
+      }
+      return response.data;
+    } catch (err) {
+      // return console.log(err);
+      return thunkApi.rejectWithValue(err);
     }
-    return response.data;
-  } catch (err) {
-    return console.log(err);
-    //   return thunkApi.rejectWithValue(err);
   }
-});
+);
 
 /* interface UserInfo {
   id: number;

--- a/client/src/stores/userInfoSlice.ts
+++ b/client/src/stores/userInfoSlice.ts
@@ -1,5 +1,4 @@
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { getLocalStorage, removeLocalStorage } from 'apis/localStorage';
 import axios from 'axios';
 
 const URL = process.env.REACT_APP_DEV_URL;
@@ -10,14 +9,6 @@ export const fetchUserInfo = createAsyncThunk(
     try {
       const response = await axios.get(`${URL}/api/users/${id}`);
       console.log('회원정보조회다!!', response.data);
-
-      /** access token 만료시 헤더에 refresh토큰 담아서 get 요청 -백엔드작업중 */
-      if (response.data === 'Access Token Expired') {
-        removeLocalStorage('access_token'); // 만료된 access토큰 삭제
-        const refreshToken = getLocalStorage('refresh_token');
-        axios.defaults.headers.common['Refresh'] = `${refreshToken}`;
-        // 새로 발급받은 access토큰으로 교체
-      }
       return response.data;
     } catch (err) {
       // return console.log(err);
@@ -26,18 +17,7 @@ export const fetchUserInfo = createAsyncThunk(
   }
 );
 
-/* interface UserInfo {
-  id: number;
-  introduction?: string | null;
-  kind: number;
-  loginId: string;
-  nickname: string;
-  picture?: string | null;
-  role?: string;
-} */
-
 interface UsersState {
-  // user: UserInfo; // 타입 에러남
   users: any;
   userId: number | undefined;
   loginId: string;

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -1,0 +1,6 @@
+export const theme = {
+  lightGrey: '#e2e6e8',
+  middleGray: '#8f8f8f',
+  accent: '#ff5924',
+  darkAccent: '#cc481d',
+};

--- a/client/src/utils/CheckJwtExp.ts
+++ b/client/src/utils/CheckJwtExp.ts
@@ -1,0 +1,21 @@
+import { getLocalStorage } from 'apis/localStorage';
+import { parseJwt } from './parseJwt';
+
+export const ACCESS_EXP_MESSAGE = 'Access Token Expired';
+export const REFRESH_EXP_MESSAGE = 'Refresh Token Expired';
+const accessToken = getLocalStorage('access_token');
+const refreshToken = getLocalStorage('refresh_token');
+
+export const CheckJWTExp = () => {
+  const decodedAccess = parseJwt(accessToken);
+  const decodedRefresh = parseJwt(refreshToken);
+  // console.log(decodedAccess, decodedRefresh); // 해부된 토큰내부 확인
+
+  if (decodedAccess?.exp * 1000 < Date.now()) {
+    return ACCESS_EXP_MESSAGE;
+  }
+  if (decodedRefresh?.exp * 1000 < Date.now()) {
+    return REFRESH_EXP_MESSAGE;
+  }
+  return true;
+};

--- a/client/src/utils/parseJwt.ts
+++ b/client/src/utils/parseJwt.ts
@@ -1,5 +1,8 @@
 import { getLocalStorage } from 'apis/localStorage';
 
+export const ACCESS_EXP_MESSAGE = 'Access Token Expired';
+export const REFRESH_EXP_MESSAGE = 'Refresh Token Expired';
+
 const accessToken = getLocalStorage('access_token');
 const refreshToken = getLocalStorage('refresh_token');
 
@@ -9,16 +12,16 @@ export const parseJwt = (token: string | null) => {
 };
 
 /** 토큰 유효기간 */
-export const AuthVerify = () => {
+export const CheckJWTExp = () => {
   const decodedAccess = parseJwt(accessToken);
   const decodedRefresh = parseJwt(refreshToken);
-  //   console.log(decodedAccess, decodedRefresh); // 해부된 토큰내부 확인
+  // console.log(decodedAccess, decodedRefresh); // 해부된 토큰내부 확인
 
-  if (decodedAccess.exp * 1000 < Date.now()) {
-    return 'Access Token Expired';
+  if (decodedAccess?.exp * 1000 < Date.now()) {
+    return ACCESS_EXP_MESSAGE;
   }
-  if (decodedRefresh.exp * 1000 < Date.now()) {
-    return 'Refresh Token Expired';
+  if (decodedRefresh?.exp * 1000 < Date.now()) {
+    return REFRESH_EXP_MESSAGE;
   }
   return true;
 };

--- a/client/src/utils/parseJwt.ts
+++ b/client/src/utils/parseJwt.ts
@@ -1,27 +1,4 @@
-import { getLocalStorage } from 'apis/localStorage';
-
-export const ACCESS_EXP_MESSAGE = 'Access Token Expired';
-export const REFRESH_EXP_MESSAGE = 'Refresh Token Expired';
-
-const accessToken = getLocalStorage('access_token');
-const refreshToken = getLocalStorage('refresh_token');
-
 /** JWT 디코딩하여 exp, id, loginId, seb 확인 */
 export const parseJwt = (token: string | null) => {
   if (token) return JSON.parse(window.atob(token.split('.')[1]));
-};
-
-/** 토큰 유효기간 */
-export const CheckJWTExp = () => {
-  const decodedAccess = parseJwt(accessToken);
-  const decodedRefresh = parseJwt(refreshToken);
-  // console.log(decodedAccess, decodedRefresh); // 해부된 토큰내부 확인
-
-  if (decodedAccess?.exp * 1000 < Date.now()) {
-    return ACCESS_EXP_MESSAGE;
-  }
-  if (decodedRefresh?.exp * 1000 < Date.now()) {
-    return REFRESH_EXP_MESSAGE;
-  }
-  return true;
 };


### PR DESCRIPTION
# access토큰 만료시 refresh토큰으로 새 access토큰 받아서 교체
- axiosConfig.ts
- 모든 요청 전 >> 액세스토큰있으면 만료됐는지 체크 후
- 만료되면 만료된 액세스와 리프레쉬 토큰 같이 헤더에 넣어서 요청
- 모든 응답 전 >>  응답헤더로 새 액세스 토큰을 받고 기존 액세스를 localStorage에서 삭제후 새걸로 교체

# 작업 
- 로그인 api 모듈로 교체
- 메인페이지 친절도 필터에서 마우스 클릭끝나면 값 적용 되도록 수정
  - 수정이유: 친절도값을 useEffect 종속성배열에 추가할 예정인데 값이 계속바뀌면 조회가 계속 갈 것 같아서 마우스 클릭 끝나면 값 적용되도록 수정

# 변경사항
- 회원조회 api - id추가해서 조회하는 걸로 수정
- App.js에서 theme을 theme.js 색상 파일로 분리  
  - accent 주황색으로 변경함 `  border: 1px solid ${(props) => props.theme.accent};` 이런식으로 사용하면 됨
- CheckJwtExp 파일 분리 - JWT디코딩해서 토큰 내부에서 만료기간 확인하는 파일
- parseJwt - JWT 디코딩하는 파일