### PR TITLE
[FE] feat: MyPage Review 버튼 활성화, 필터 params 수정, 헤더 수정

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,6 +15,7 @@ import ProgDetail from 'pages/ProgDetail';
 import ProgUpdate from 'pages/ProgUpdate';
 import { theme } from 'theme';
 import Hero from 'pages/Hero';
+import ReviewCreate from 'pages/ReviewCreate';
 
 const App: React.FC = () => {
   return (
@@ -38,6 +39,7 @@ const App: React.FC = () => {
             <Route path="/notice" element={<NoticeList />} />
             <Route path="/notice/:noticeId" element={<NoticeDetail />} />
             <Route path="/notice/create" element={<NoticeCreate />} />
+            <Route path="/reviews/:applyId" element={<ReviewCreate />} />
           </Routes>
           <Footer />
         </BrowserRouter>

--- a/client/src/components/AreaFilter.tsx
+++ b/client/src/components/AreaFilter.tsx
@@ -49,9 +49,11 @@ export const DropDouwnList = styled.li`
 
 interface AreaProps {
   setAreaSelected?: React.Dispatch<React.SetStateAction<string>>;
+  setParamsData?: any;
+  paramsData?: any;
 }
 
-function AreaFilter({ setAreaSelected }: AreaProps) {
+function AreaFilter({ setAreaSelected, setParamsData, paramsData }: AreaProps) {
   const [isClicked, setIsClicked] = useState<boolean>(false);
   const [area, setArea] = useState<string>('지역');
 
@@ -66,8 +68,16 @@ function AreaFilter({ setAreaSelected }: AreaProps) {
     if (setAreaSelected) {
       if ((e.target as any).textContent === '전체') {
         setAreaSelected('');
+        setParamsData({
+          ...paramsData,
+          location: '',
+        });
       } else {
         setAreaSelected((e.target as any).textContent);
+        setParamsData({
+          ...paramsData,
+          location: (e.target as any).textContent,
+        });
       }
     }
   };

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -11,6 +11,7 @@ import Profile from '../images/Profile.svg';
 import { logoutUser } from 'stores/userInfoSlice';
 import { removeLocalStorage } from 'apis/localStorage';
 import { byteToBase64 } from 'utils/byteToBase64';
+import axios from 'axios';
 
 const HeaderContainer = styled.div`
   position: fixed;
@@ -203,10 +204,10 @@ export default function Header() {
     (state) => state.userInfo
   );
 
-  const handelSearchSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handelSearchSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     dispatch(searchActions.getKeyword(InputValue)); //헤더 input값 전역상태에 저장
-    navigate('/'); // 엔터 시 질문목록 메인페이지로 이동
+    navigate('/programs'); // 엔터 시 질문목록 메인페이지로 이동
     setInputValue(''); // input창 초기화
   };
   const handleLogoutBtn = () => {

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -273,7 +273,7 @@ export default function Header() {
                   <ProfileBtn onClick={() => setIsOpened(!isopened)}>
                     <img
                       src={
-                        users?.userImages[0]?.length === 0
+                        users?.userImages?.length !== 0
                           ? byteToBase64(
                               users?.userImages[0]?.contentType,
                               users?.userImages[0]?.bytes
@@ -308,7 +308,7 @@ export default function Header() {
                   <UserProfileImg>
                     <img
                       src={
-                        users?.userImages[0]?.length === 0
+                        users?.userImages?.length !== 0
                           ? byteToBase64(
                               users?.userImages[0]?.contentType,
                               users?.userImages[0]?.bytes

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -231,7 +231,7 @@ export default function Header() {
               <Link to="/">홈</Link>
             </HeaderLinkText>
             <HeaderLinkText>
-              <Link to="/programs">모임 목록 </Link>
+              <Link to="/programs">프로그램 / 모임 목록 </Link>
             </HeaderLinkText>
 
             <SearchForm onSubmit={handelSearchSubmit}>
@@ -272,7 +272,7 @@ export default function Header() {
                   <ProfileBtn onClick={() => setIsOpened(!isopened)}>
                     <img
                       src={
-                        users?.userImages
+                        users?.userImages[0]?.length === 0
                           ? byteToBase64(
                               users?.userImages[0]?.contentType,
                               users?.userImages[0]?.bytes
@@ -307,7 +307,7 @@ export default function Header() {
                   <UserProfileImg>
                     <img
                       src={
-                        users?.userImages
+                        users?.userImages[0]?.length === 0
                           ? byteToBase64(
                               users?.userImages[0]?.contentType,
                               users?.userImages[0]?.bytes

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -29,6 +29,7 @@ const IngContainer = styled.div``;
 const FilterContainer = styled.div`
   display: flex;
   margin-bottom: 1rem;
+  justify-content: space-between;
 `;
 const DateInput = styled.input`
   height: 30px;
@@ -139,13 +140,20 @@ const ProgWrapper = styled.div`
 `;
 const ProgPerson = styled.div``;
 const ProgDate = styled.div``;
-const DoneContainer = styled.div`
-  padding: 7rem 0;
+const FilterRowWrapper = styled.div`
+  display: flex;
+  align-items: center;
 `;
-const DoneProgEmptyMsg = styled.div`
-  margin-top: 1rem;
-  font-weight: 300;
+const StatusIng = styled.button`
+  border: none;
+  &:hover {
+    font-weight: 600;
+  }
 `;
+const StatusDeadLine = styled(StatusIng)`
+  margin-left: 1rem;
+`;
+const StatusEnd = styled(StatusDeadLine)``;
 
 export default function Main() {
   const URL = process.env.REACT_APP_DEV_URL;
@@ -158,7 +166,7 @@ export default function Main() {
   const [programs, setPrograms] = useState<Array<ProgramDetailVal>>([]);
   const [pageList, setPageList] = useState();
   const [page, setPage] = useState<number>(1);
-  const [programStatus, setProgramStatus] = useState('모집중');
+  const [programStatus, setProgramStatus] = useState('');
   const [minKindVal, setMinKindVal] = useState('');
   const [donePrograms, setDonePrograms] = useState<Array<ProgramDetailVal>>([]);
   const [bookmarked, setBookmarked] = useState<boolean>(false);
@@ -186,7 +194,7 @@ export default function Main() {
   useEffect(() => {
     const getProgramList = async () => {
       await axios
-        .get(`${URL}/api/programs?page=${page}&size=10`, {
+        .get(`${URL}/api/programs?page=${page}&size=12`, {
           params: REQ_PARAMS,
         })
         .then(({ data }) => {
@@ -209,6 +217,8 @@ export default function Main() {
     minKindVal,
     bookmarked,
   ]);
+
+  console.log(REQ_PARAMS);
 
   const handleBookedToggle = async (id: number, bookmarkId: number) => {
     if (bookmarkId === null) {
@@ -235,48 +245,64 @@ export default function Main() {
     setBookmarked(!bookmarked);
   };
 
+  const handleStatusIng = () => {
+    console.log('모집중');
+    setProgramStatus('모집중');
+  };
+
   return (
     <Layout>
       <WrapContainer>
         <IngContainer>
-          <RecruitText>모집 중인 모임</RecruitText>
+          <RecruitText>모집 중인 프로그램 / 모임</RecruitText>
           <FilterContainer>
-            <AreaFilter setAreaSelected={setAreaSelected} />
-            <DateInput
-              type="text"
-              required
-              placeholder="날짜 선택"
-              aria-required="true"
-              onBlur={(e) => (e.target.type = 'text')}
-              onChange={(e) => setDateSelected(e.target.value)}
-              onFocus={(e) => (e.target.type = 'date')}
-              min={getToday()}
-            />
-            <LevelRange onClick={() => setLevelOpened(!levelOpened)}>
-              친절도 &nbsp;{minKindVal}%
-              <img src={QuestionMark} alt="question mark" />
-              <img src={DownArrow} alt="down arrow" />
-              {levelOpened ? (
-                <WrapLevel>
-                  <WrapLevelSpan>
-                    <WrapLevelLabel>친절도 범위</WrapLevelLabel>
-                    <WrapLevelText>
-                      * 최소 친절 % 범위를 선택해보세요.
-                    </WrapLevelText>
-                  </WrapLevelSpan>
-                  <WrapLevelRangeInput
-                    type="range"
-                    min={0}
-                    max={100}
-                    step={1}
-                    onChange={(e) => setRangeValue(e.target.value)}
-                    defaultValue={minKindVal}
-                    onMouseUp={() => setMinKindVal(rangeValue)}
-                  />
-                  <RangeValue>{rangeValue}%</RangeValue>
-                </WrapLevel>
-              ) : null}
-            </LevelRange>
+            <FilterRowWrapper>
+              <AreaFilter setAreaSelected={setAreaSelected} />
+              <DateInput
+                type="text"
+                required
+                placeholder="날짜 선택"
+                aria-required="true"
+                onBlur={(e) => (e.target.type = 'text')}
+                onChange={(e) => setDateSelected(e.target.value)}
+                onFocus={(e) => (e.target.type = 'date')}
+                min={getToday()}
+              />
+              <LevelRange onClick={() => setLevelOpened(!levelOpened)}>
+                친절도 &nbsp;{minKindVal}%
+                <img src={QuestionMark} alt="question mark" />
+                <img src={DownArrow} alt="down arrow" />
+                {levelOpened ? (
+                  <WrapLevel>
+                    <WrapLevelSpan>
+                      <WrapLevelLabel>친절도 범위</WrapLevelLabel>
+                      <WrapLevelText>
+                        * 최소 친절 % 범위를 선택해보세요.
+                      </WrapLevelText>
+                    </WrapLevelSpan>
+                    <WrapLevelRangeInput
+                      type="range"
+                      min={0}
+                      max={100}
+                      step={1}
+                      onChange={(e) => setRangeValue(e.target.value)}
+                      defaultValue={minKindVal}
+                      onMouseUp={() => setMinKindVal(rangeValue)}
+                    />
+                    <RangeValue>{rangeValue}%</RangeValue>
+                  </WrapLevel>
+                ) : null}
+              </LevelRange>
+            </FilterRowWrapper>
+            <FilterRowWrapper>
+              <StatusIng onClick={handleStatusIng}>• 모집중</StatusIng>
+              <StatusDeadLine onClick={() => setProgramStatus('마감임박')}>
+                • 마감임박
+              </StatusDeadLine>
+              <StatusEnd onClick={() => setProgramStatus('마감')}>
+                • 마감
+              </StatusEnd>
+            </FilterRowWrapper>
           </FilterContainer>
           <ProgContainer>
             {programs &&
@@ -353,77 +379,6 @@ export default function Main() {
           </ProgContainer>
           <Pagination list={pageList} page={page} setPage={setPage} />
         </IngContainer>
-        <DoneContainer>
-          <RecruitText>모집 마감된 모임</RecruitText>
-          <ProgContainer>
-            {donePrograms[0] !== undefined ? (
-              donePrograms?.map((el: any) => (
-                <ProgItem key={el.id}>
-                  <ProgBanner>
-                    <ProgRecruitment
-                      style={{
-                        backgroundColor: `${
-                          el.programStatus === '모집중'
-                            ? '#38D9A9'
-                            : null || el.programStatus === '마감임박'
-                            ? '#d22a2a'
-                            : null || el.programStatus === '마감'
-                            ? 'darkGray'
-                            : null
-                        }`,
-                      }}
-                    >
-                      {el?.programStatus}
-                    </ProgRecruitment>
-                    <img
-                      src={
-                        el?.programImages.length === 0
-                          ? BasicImg
-                          : `data:${el.programImages[0].contentType};base64,${el?.programImages[0].bytes}`
-                      }
-                      style={{
-                        height: '180px',
-                        width: '100%',
-                        borderRadius: '5px',
-                      }}
-                      alt="program Image"
-                      loading="lazy"
-                    />
-                    <ProgBookmark>
-                      <img src={Bookmark} alt="bookmark" />
-                    </ProgBookmark>
-                  </ProgBanner>
-                  <ProgTitle>
-                    [{el.location}] {el.title.slice(0, 16)}...
-                  </ProgTitle>
-                  <LevelPercent percent={el.minKind} />
-                  <ProgProgressBar>
-                    <ProgressBar
-                      currentPerson={el.numOfRecruits}
-                      totalPerson={el.numOfRecruits}
-                    />
-                  </ProgProgressBar>
-                  <ProgWrapper>
-                    <ProgPerson>
-                      모집인원 {el.numOfRecruits} / {el.numOfRecruits}
-                    </ProgPerson>
-                    <ProgDate>
-                      {Math.floor(
-                        (+new Date(el.programDate) - +new Date()) /
-                          (1000 * 60 * 60 * 24)
-                      )}
-                      일 남음
-                    </ProgDate>
-                  </ProgWrapper>
-                </ProgItem>
-              ))
-            ) : (
-              <DoneProgEmptyMsg>
-                &nbsp;&nbsp;마감된 모임이 없습니다
-              </DoneProgEmptyMsg>
-            )}
-          </ProgContainer>
-        </DoneContainer>
       </WrapContainer>
     </Layout>
   );

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -14,7 +14,7 @@ import { useAppSelector } from 'stores/hooks';
 import { getisLoggedIn, getUserData, getUserError } from 'stores/userInfoSlice';
 import BasicImg from '../images/BasicImg.jpg';
 import Pagination from 'pagination/Pagination';
-import { ProgramDetailVal } from 'types/programs';
+import { FilterParamsProp, ProgramDetailVal } from 'types/programs';
 import { getToday } from 'utils/getToday';
 
 const WrapContainer = styled.div`
@@ -171,6 +171,7 @@ export default function Main() {
   const [donePrograms, setDonePrograms] = useState<Array<ProgramDetailVal>>([]);
   const [bookmarked, setBookmarked] = useState<boolean>(false);
   const [bookmarkedId, setBookmarkedId] = useState<any>(null);
+  const [paramsData, setParamsData] = useState<FilterParamsProp>({});
 
   /** 유저 전역상태 전체 - users, isLoggedIn, loading, error  */
   const loginUserInfo = useAppSelector((state) => state.userInfo);
@@ -182,20 +183,16 @@ export default function Main() {
   const userError = useAppSelector(getUserError); // 에러내용
   // console.log('유저 전역상태: ', isLoggedIn, userData, userError); // 확인 후 주석해제하면 됩니다
 
-  const REQ_PARAMS = {
-    keyword: searchKeyword,
-    location: areaSelected,
-    minKind: minKindVal,
-    programDate: dateSelected,
-    programStatus: programStatus,
-  };
-
   /** 필터 조회api - 키워드,지역,날짜,친절도*/
+  /*  useEffect(() => {
+    setParamsData({ ...paramsData, keyword: searchKeyword });
+  }, []); */
+
   useEffect(() => {
     const getProgramList = async () => {
       await axios
         .get(`${URL}/api/programs?page=${page}&size=12`, {
-          params: REQ_PARAMS,
+          params: { ...paramsData, keyword: searchKeyword },
         })
         .then(({ data }) => {
           // console.log(data?.data);
@@ -208,6 +205,7 @@ export default function Main() {
         })
         .catch((err) => console.log(err.message));
     };
+
     getProgramList();
   }, [
     searchKeyword,
@@ -216,9 +214,8 @@ export default function Main() {
     programStatus,
     minKindVal,
     bookmarked,
+    paramsData,
   ]);
-
-  console.log(REQ_PARAMS);
 
   const handleBookedToggle = async (id: number, bookmarkId: number) => {
     if (bookmarkId === null) {
@@ -245,9 +242,17 @@ export default function Main() {
     setBookmarked(!bookmarked);
   };
 
+  // const getProgramsApplyList = async (programId: number) => {
+  //   await axios
+  //     .get(`${URL}/api/applies?page=1&size=32&programId=${programId}`)
+  //     .then((res) => {
+  //       console.log;
+  //     });
+  // };
+
   const handleStatusIng = () => {
     console.log('모집중');
-    setProgramStatus('모집중');
+    setParamsData({ ...paramsData, programStatus: '모집중' });
   };
 
   return (
@@ -257,14 +262,20 @@ export default function Main() {
           <RecruitText>모집 중인 프로그램 / 모임</RecruitText>
           <FilterContainer>
             <FilterRowWrapper>
-              <AreaFilter setAreaSelected={setAreaSelected} />
+              <AreaFilter
+                setAreaSelected={setAreaSelected}
+                setParamsData={setParamsData}
+                paramsData={paramsData}
+              />
               <DateInput
                 type="text"
                 required
                 placeholder="날짜 선택"
                 aria-required="true"
                 onBlur={(e) => (e.target.type = 'text')}
-                onChange={(e) => setDateSelected(e.target.value)}
+                onChange={(e) =>
+                  setParamsData({ ...paramsData, programDate: e.target.value })
+                }
                 onFocus={(e) => (e.target.type = 'date')}
                 min={getToday()}
               />
@@ -287,7 +298,9 @@ export default function Main() {
                       step={1}
                       onChange={(e) => setRangeValue(e.target.value)}
                       defaultValue={minKindVal}
-                      onMouseUp={() => setMinKindVal(rangeValue)}
+                      onMouseUp={() =>
+                        setParamsData({ ...paramsData, minKind: rangeValue })
+                      }
                     />
                     <RangeValue>{rangeValue}%</RangeValue>
                   </WrapLevel>
@@ -295,11 +308,25 @@ export default function Main() {
               </LevelRange>
             </FilterRowWrapper>
             <FilterRowWrapper>
-              <StatusIng onClick={handleStatusIng}>• 모집중</StatusIng>
-              <StatusDeadLine onClick={() => setProgramStatus('마감임박')}>
+              <StatusIng
+                onClick={() =>
+                  setParamsData({ ...paramsData, programStatus: '모집중' })
+                }
+              >
+                • 모집중
+              </StatusIng>
+              <StatusDeadLine
+                onClick={() =>
+                  setParamsData({ ...paramsData, programStatus: '마감임박' })
+                }
+              >
                 • 마감임박
               </StatusDeadLine>
-              <StatusEnd onClick={() => setProgramStatus('마감')}>
+              <StatusEnd
+                onClick={() =>
+                  setParamsData({ ...paramsData, programStatus: '마감' })
+                }
+              >
                 • 마감
               </StatusEnd>
             </FilterRowWrapper>

--- a/client/src/pages/MyPage.tsx
+++ b/client/src/pages/MyPage.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import ProgressBar from 'components/ProgressBar';
 import LevelPercent from 'components/LevelPercent';
 import QuestionMark from '../images/QuestionMark.svg';
-import BookMarkTab from 'components/Tab/BookMarkTab';
+import BookMarkTab, { DoneMsg } from 'components/Tab/BookMarkTab';
 import MessageTab from 'components/Tab/MessageTab';
 import Pagination from 'pagination/Pagination';
 import { Link, useParams, useNavigate } from 'react-router-dom';
@@ -12,11 +12,13 @@ import ProfileSvg from '../images/Profile.svg';
 import axios from 'axios';
 import { UserVal, SignUpVal } from 'types/user';
 import { ApplyListVal, PaginationVal, ProgramDetailVal } from 'types/programs';
-import { setSourceMapRange } from 'typescript';
 import ImgDeleteBtnSvg from '../images/ImgDeleteBtn.svg';
 import { ImgDeleteBtn } from './ProgUpdate';
 import { useAppDispatch } from 'stores/hooks';
 import { fetchUserInfo } from 'stores/userInfoSlice';
+import BasicImg from '../images/BasicImg.jpg';
+import { compareWithToday } from '../utils/compareWithToday';
+import { byteToBase64 } from '../utils/byteToBase64';
 
 const MyPageContainer = styled.div`
   display: flex;
@@ -43,8 +45,6 @@ const ProfileWrap = styled.div`
 `;
 
 const ProfileImage = styled.div`
-  /* width: 7rem;
-  height: 7rem; */
   margin: 1rem;
   background-color: #e2e6e8;
   border-radius: 50%;
@@ -161,7 +161,6 @@ export const ClubItem = styled.div`
   border-radius: 5px;
 `;
 export const ClubImg = styled.div`
-  /* border: 0.7px solid gray; */
   border-radius: 50%;
   width: 35px;
   height: 30px;
@@ -297,12 +296,44 @@ function MyPage() {
             {programs?.map((el: any) => (
               <Link to={`/programs/${el?.program.id}`} key={el?.program.id}>
                 <ClubItem key={el?.id}>
-                  <ClubImg></ClubImg>
+                  <ClubImg>
+                    <img
+                      src={
+                        el?.program?.programImages?.length === 0
+                          ? BasicImg
+                          : byteToBase64(
+                              el?.program?.programImages[0]?.contentType,
+                              el?.program?.programImages[0]?.bytes
+                            )
+                      }
+                      alt="basicImg"
+                      style={{
+                        height: 40,
+                        width: 40,
+                        borderRadius: 50,
+                      }}
+                      loading="lazy"
+                    />
+                  </ClubImg>
+                  <DoneMsg
+                    style={{
+                      backgroundColor:
+                        compareWithToday(el?.program?.programDate) ===
+                        '모임종료'
+                          ? 'rgba(81, 81, 81, 0.469)'
+                          : 'none',
+                    }}
+                  >
+                    {compareWithToday(el?.program?.programDate) === '모임종료'
+                      ? '종료'
+                      : null}
+                  </DoneMsg>
                   <ClubInfo>
                     <ClubTitle>{el?.program.title}</ClubTitle>
                     <ClubBody>{el?.program.text}</ClubBody>
                     <ClubDate>
-                      {el?.program.programDate} {el?.program.programStatus}
+                      {el?.program.programDate}{' '}
+                      {compareWithToday(el?.program?.programDate)}
                     </ClubDate>
                   </ClubInfo>
                 </ClubItem>
@@ -315,12 +346,43 @@ function MyPage() {
             {opens?.map((el: any) => (
               <Link to={`/programs/${el?.id}`} key={el?.id}>
                 <ClubItem key={el?.id}>
-                  <ClubImg></ClubImg>
+                  <ClubImg>
+                    {' '}
+                    <img
+                      src={
+                        el?.programImages?.length === 0
+                          ? BasicImg
+                          : byteToBase64(
+                              el?.programImages[0]?.contentType,
+                              el?.programImages[0]?.bytes
+                            )
+                      }
+                      alt="basicImg"
+                      style={{
+                        height: 40,
+                        width: 40,
+                        borderRadius: 50,
+                      }}
+                      loading="lazy"
+                    />
+                  </ClubImg>
+                  <DoneMsg
+                    style={{
+                      backgroundColor:
+                        compareWithToday(el?.programDate) === '모임종료'
+                          ? 'rgba(81, 81, 81, 0.469)'
+                          : 'none',
+                    }}
+                  >
+                    {compareWithToday(el?.programDate) === '모임종료'
+                      ? '종료'
+                      : null}
+                  </DoneMsg>
                   <ClubInfo>
                     <ClubTitle>{el?.title}</ClubTitle>
                     <ClubBody>{el?.text}</ClubBody>
                     <ClubDate>
-                      {el?.programDate} {el?.programStatus}
+                      {el?.programDate} {compareWithToday(el?.programDate)}
                     </ClubDate>
                   </ClubInfo>
                 </ClubItem>

--- a/client/src/types/programs.tsx
+++ b/client/src/types/programs.tsx
@@ -42,3 +42,11 @@ export interface PaginationVal {
   totalElements: number;
   totalPages: number;
 }
+
+export interface FilterParamsProp {
+  keyword?: string;
+  location?: string;
+  minKind?: string;
+  programDate?: string;
+  programStatus?: string;
+}


### PR DESCRIPTION
# 수정사항
- Header 프로필 이미지 수정
- 메인 필터 params 수정
- 마이페이지 css 수정
- 수정전 - 왼쪽 공간으로 인해 오른쪽 부분에 리뷰버튼 들어가면 공간이 좁은 문제
<img width="1277" alt="스크린샷 2022-10-04 오후 3 56 13" src="https://user-images.githubusercontent.com/77045939/193764168-896a851d-4345-4349-8421-a3a88a4c1fde.png">

- 수정후
<img width="1194" alt="스크린샷 2022-10-04 오후 3 56 55" src="https://user-images.githubusercontent.com/77045939/193762815-f6c4d85f-0a38-4018-b97a-bf98f07b373b.png">


# 작업
1. 마이페이지
- 내모임탭 img, 종료 메시지
- 종료되면 리뷰버튼 활성화
- 리뷰버튼 누르면 리뷰작성 페이지로 이동
<img width="964" alt="스크린샷 2022-10-04 오후 4 16 46" src="https://user-images.githubusercontent.com/77045939/193762939-3c80bf79-5ec5-49c8-829c-227b83b5cca8.png">


# 못한 것
### 문제 1
- 문제
메인 필터가 params로 들어가는데 기존엔 `keyword=&location=&minKind=&programDate=&programStatus=` 이렇게 값이 없어도 api로 전송되는 문제
- 현재상황
검색창 값만 빼고 나머지 필터값들은 값이 없으면 param에 안 담기게 함
- 추후 수정예정 사항
검색키워드 값을 전역상태에서 가져오는데 헤더에서 엔터치는 순간 params에 담기게 해야 함 


<br />

- 메인페이지 현재인원수 조회

