### PR TITLE
[BE] fix : userPost API and deleteUser

### DIFF
--- a/server/src/main/java/com/codestates/team5/dailyclub/config/SwaggerConfig.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/config/SwaggerConfig.java
@@ -19,7 +19,7 @@ public class SwaggerConfig {
     public GroupedOpenApi openApi() {
         return GroupedOpenApi.builder()
                 .group("DailyClub API 명세서")
-                .pathsToMatch("/api/**")
+                .pathsToMatch("/api/**","/join")
                 .build();
     }
 

--- a/server/src/main/java/com/codestates/team5/dailyclub/user/controller/UserController.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/user/controller/UserController.java
@@ -37,7 +37,7 @@ public class UserController {
     @Operation(summary = "회원가입")
     @ApiResponse(responseCode = "201", description = "CREATED", content = @Content(schema = @Schema(implementation = UserDto.Response.class)))
     @PostMapping(value = "/join", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> postUser(@RequestBody UserDto.Post requestBody) {
+    public ResponseEntity<?> joinUser(@RequestBody UserDto.Post requestBody) {
         User response = userService.createUser(requestBody);
         return new ResponseEntity<>(userMapper.userToUserResponseDto(response), HttpStatus.CREATED);
 
@@ -46,7 +46,7 @@ public class UserController {
     @Operation(summary = "회원 조회")
     @ApiResponse(responseCode = "200", description = "OK",content = @Content(schema = @Schema(implementation = UserDto.Response.class)))
     @GetMapping(value = "/api/users/{userId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> getUser(@PathVariable("userId") long id) {
+    public ResponseEntity<?> getUser(@PathVariable("userId") Long id) {
         User response = userService.findUser(id);
         return new ResponseEntity<>(userMapper.userToUserResponseDto(response), HttpStatus.OK);
     }
@@ -54,8 +54,10 @@ public class UserController {
     @Operation(summary = "회원 탈퇴")
     @ApiResponse(responseCode = "204", description = "NOT CONTENT")
     @DeleteMapping(value = "/api/users/{userId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public void deleteUser (@PathVariable("userId") long id) {
-        userService.deleteUser(id);
+    public String deleteUser (@PathVariable("userId") Long id, @Parameter(hidden =true) @AuthenticationPrincipal AuthDetails authDetails) {
+        Long loginUserId = authDetails.getUserId();
+        userService.deleteUser(id, loginUserId);
+        return "회원 탈퇴가 완료되었습니다.";
     }
 
 
@@ -64,7 +66,7 @@ public class UserController {
     @PatchMapping(value = "/api/users/{userId}",  consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> patchUser(@ParameterObject @ModelAttribute UserDto.Patch userPatchDto,
                                        @RequestPart(required = false) MultipartFile imageFile,
-                                       @PathVariable("userId") Long userId, @Parameter(hidden =true) @AuthenticationPrincipal AuthDetails authDetails) throws IOException {
+                                       @PathVariable("userId") Long id, @Parameter(hidden =true) @AuthenticationPrincipal AuthDetails authDetails) throws IOException {
         Long loginUserId = authDetails.getUserId();
         User userFromPatchDto = userMapper.userPatchToUser(userPatchDto);
         User response = userService.updateUser(

--- a/server/src/main/java/com/codestates/team5/dailyclub/user/controller/UserController.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/user/controller/UserController.java
@@ -30,39 +30,38 @@ import java.util.List;
 @Tag(name = "유저 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/users")
 public class UserController {
     private final UserService userService;
     private final UserMapper userMapper;
 
     @Operation(summary = "회원가입")
     @ApiResponse(responseCode = "201", description = "CREATED", content = @Content(schema = @Schema(implementation = UserDto.Response.class)))
-    @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/join", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> postUser(@RequestBody UserDto.Post requestBody) {
         User response = userService.createUser(requestBody);
         return new ResponseEntity<>(userMapper.userToUserResponseDto(response), HttpStatus.CREATED);
 
     }
 
-    @Operation(summary = "회원 한명 조회")
+    @Operation(summary = "회원 조회")
     @ApiResponse(responseCode = "200", description = "OK",content = @Content(schema = @Schema(implementation = UserDto.Response.class)))
-    @GetMapping(value = "/{userId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> getUser(@PathVariable("userId") Long id) {
+    @GetMapping(value = "/api/users/{userId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> getUser(@PathVariable("userId") long id) {
         User response = userService.findUser(id);
         return new ResponseEntity<>(userMapper.userToUserResponseDto(response), HttpStatus.OK);
     }
 
     @Operation(summary = "회원 탈퇴")
     @ApiResponse(responseCode = "204", description = "NOT CONTENT")
-    @DeleteMapping(value = "/{userId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public void deleteUser (@PathVariable("userId") Long id, @Parameter(hidden =true) @AuthenticationPrincipal AuthDetails authDetails) throws IOException {
+    @DeleteMapping(value = "/api/users/{userId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public void deleteUser (@PathVariable("userId") long id) {
         userService.deleteUser(id);
     }
 
 
     @Operation(summary = "회원정보 수정")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = UserDto.Response.class)))
-    @PatchMapping(value = "{userId}",  consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PatchMapping(value = "/api/users/{userId}",  consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> patchUser(@ParameterObject @ModelAttribute UserDto.Patch userPatchDto,
                                        @RequestPart(required = false) MultipartFile imageFile,
                                        @PathVariable("userId") Long userId, @Parameter(hidden =true) @AuthenticationPrincipal AuthDetails authDetails) throws IOException {

--- a/server/src/main/java/com/codestates/team5/dailyclub/user/service/UserService.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/user/service/UserService.java
@@ -83,7 +83,15 @@ public class UserService {
 
     }
 
-    public void deleteUser(Long id) {
+    public void deleteUser(Long id, Long loginUserId) {
+        User findUser = userRepository.findById(id).orElseThrow(
+                ()-> new BusinessLogicException(ExceptionCode.USER_NOT_FOUND)
+        );
+
+        if(!findUser.getId().equals(loginUserId)) {
+            throw new BusinessLogicException(ExceptionCode.CANNOT_DELETE_USERS);
+        }
+
         userRepository.deleteById(id);
     }
 }


### PR DESCRIPTION
SecurityConfig에 Post 요청 "/api/**"가 걸려있어서 인증되지 않은 사용자가 접근하지 못하는 결함이 있었습니다.
그래서 회원가입은 "/join"으로 API 주소를 따로 빼고 그에따라 swaggerConfig pathToMatch도 수정 했습니다
유저 삭제하는 부분에서 로그인된 유저만 삭제할 수 있도록 service 부분을 수정하였습니다. 
또한 controller 부분에서 long으로  되어있는 부분은 Long으로 변경하였습니다.

*커밋 메세지가 작성 오류 
[BE] fix: findUser -> [BE] fix: deleteUser