### PR TITLE
[BE] feat: add @Unique with validation for user join

### DIFF
--- a/server/src/main/java/com/codestates/team5/dailyclub/program/dto/ProgramDto.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/program/dto/ProgramDto.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.Range;
+import org.hibernate.validator.constraints.UniqueElements;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.validation.constraints.NotNull;
@@ -30,10 +31,12 @@ public class ProgramDto {
     public static class Post {
         @Schema(description = "프로그램 제목", example = "제목")
         @Length(min = 5, max = 30)
+        @NotNull
         private String title;
 
         @Schema(description = "프로그램 본문", example = "본문")
         @Length(min = 1, max = 1000)
+        @NotNull
         private String text;
 
         @Schema(description = "모집 인원", example = "10")
@@ -64,15 +67,17 @@ public class ProgramDto {
     @Builder
     public static class Patch {
         @Schema(description = "프로그램 ID", example = "4")
-        @Positive
+        @NotNull
         private Long id;
 
         @Schema(description = "프로그램 제목", example = "한강 달리기 하실 분??")
         @Length(min = 5, max = 30)
+        @NotNull
         private String title;
 
         @Schema(description = "프로그램 본문", example = "10/18 여의도 한강공원에서 저녁 8시에 같이 달리실 분 모집합니다.")
         @Length(min = 1, max = 1000)
+        @NotNull
         private String text;
 
         @Schema(description = "모집 인원", example = "7")
@@ -97,7 +102,6 @@ public class ProgramDto {
         private Integer minKind;
 
         @Schema(description = "프로그램 이미지 ID")
-        @Positive
         private Long programImageId;
     }
 
@@ -135,6 +139,9 @@ public class ProgramDto {
 
         @Schema(description = "인원 상태", example = "모집중", allowableValues = {"모집중", "마감임박", "마감"})
         private String programStatus;
+
+        @Schema(description = "신청 인원 수")
+        private int numOfApplicants;
 
         @Schema(description = "북마크 ID")
         private Long bookmarkId;

--- a/server/src/main/java/com/codestates/team5/dailyclub/user/repository/UserRepository.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/user/repository/UserRepository.java
@@ -14,4 +14,7 @@ public interface UserRepository extends JpaRepository <User, Long> {
     @Query("select u from User u where u.loginId = :loginId")
     Optional<User> findByLoginId(@Param("loginId") String loginId);
 
+    boolean existsByLoginId(@Param("loginId") String loginId);
+    boolean existsByNickname(@Param("nickname") String nickname);
+    boolean existsByEmail(@Param("email") String email);
 }

--- a/server/src/main/java/com/codestates/team5/dailyclub/validator/annotation/Unique.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/validator/annotation/Unique.java
@@ -1,0 +1,20 @@
+package com.codestates.team5.dailyclub.validator.annotation;
+
+import com.codestates.team5.dailyclub.validator.validator.UniqueValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = UniqueValidator.class)
+public @interface Unique {
+    String message() default "중복된 값입니다.";
+    String value();
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/server/src/main/java/com/codestates/team5/dailyclub/validator/validator/UniqueValidator.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/validator/validator/UniqueValidator.java
@@ -1,0 +1,37 @@
+package com.codestates.team5.dailyclub.validator.validator;
+
+import com.codestates.team5.dailyclub.user.dto.UserDto;
+import com.codestates.team5.dailyclub.user.repository.UserRepository;
+import com.codestates.team5.dailyclub.validator.annotation.Unique;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+@RequiredArgsConstructor
+@Slf4j
+public class UniqueValidator implements ConstraintValidator<Unique, String> {
+
+    private final UserRepository userRepository;
+    private String fieldName;
+
+    @Override
+    public void initialize(Unique unique) {
+        this.fieldName = unique.value();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        log.info("[UniqueValidator] 동작 = {}", fieldName);
+        switch (fieldName) {
+            case "loginId" :
+                return !userRepository.existsByLoginId(value);
+            case "nickname" :
+                return !userRepository.existsByNickname(value);
+            case "email" :
+                return !userRepository.existsByEmail(value);
+        }
+        return false;
+    }
+}

--- a/server/src/main/resources/errors.properties
+++ b/server/src/main/resources/errors.properties
@@ -19,8 +19,14 @@ NotNull.numOfRecruits = 모집 인원은 필수 값입니다.
 NotNull.minKind = 최소 신청 가능 친절 %는 필수 값입니다.
 NotNull.applyId = 신청 ID는 필수 값입니다.
 NotNull.score = 프로그램 만족도는 필수 값입니다.
+NotNul.title = 제목은 필수 값입니다.
+NotNull.text = 본문은 필수 값입니다.
+NotNull.id = ID는 필수 값입니다.
 Range.numOfRecruits = 모집 인원은 {2} ~ {1}명 사이여야 합니다.
 Range.minKind = 최소 신청 가능 친절 %는 {2} ~ {1}% 사이여야 합니다.
+Unique.loginId = 이미 사용 중인 로그인 ID입니다.
+Unique.nickname = 이미 사용 중인 닉네임입니다.
+Unique.email = 이미 사용 중인 이메일입니다.
 
 
 
@@ -36,3 +42,4 @@ TodayOrAfter = 오늘보다 이전 날짜를 지정할 수 없습니다.
 Location = 올바른 지역명을 입력해야 합니다.
 ProgramStatus = 올바른 프로그램 상태를 입력해야 합니다. (모집중, 마감임박, 마감)
 typeMismatch = 타입 오류입니다.
+Unique = 중복 값입니다.


### PR DESCRIPTION
1. `@Unique` validation 필드 별로 동작하도록 작성했습니다.
error.properties에 에러 메시지도 추가했습니다.

`@Unique` validator에서 UserRepository에 exists query를 보내는 방식입니다.

사용법은 `@Unique("nickname")` 처럼 사용하는 필드 이름을 넣으시면 됩니다.

2. ProgramDto에서 title과 text `@NotNull` validation 추가하고 에러 메시지 추가했습니다.