### PR TITLE
[BE] fix: add Validation and updateUser Methods

### DIFF
--- a/server/src/main/java/com/codestates/team5/dailyclub/image/entity/UserImage.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/image/entity/UserImage.java
@@ -8,6 +8,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -21,7 +23,7 @@ public class UserImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;

--- a/server/src/main/java/com/codestates/team5/dailyclub/message/entity/Message.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/message/entity/Message.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -22,10 +24,12 @@ public class Message extends Auditable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "from_user_id")
     private User fromUser;
 
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "to_user_id")
     private User toUser;

--- a/server/src/main/java/com/codestates/team5/dailyclub/notification/entity/Notification.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/notification/entity/Notification.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -22,6 +24,7 @@ public class Notification extends Auditable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;

--- a/server/src/main/java/com/codestates/team5/dailyclub/user/controller/UserController.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/user/controller/UserController.java
@@ -1,6 +1,5 @@
 package com.codestates.team5.dailyclub.user.controller;
 
-import com.codestates.team5.dailyclub.common.dto.MultiResponseDto;
 import com.codestates.team5.dailyclub.jwt.AuthDetails;
 import com.codestates.team5.dailyclub.user.dto.UserDto;
 import com.codestates.team5.dailyclub.user.entity.User;
@@ -15,7 +14,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.api.annotations.ParameterObject;
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +23,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.List;
+
 @Slf4j
 @Tag(name = "유저 API")
 @RestController
@@ -35,11 +33,12 @@ public class UserController {
     private final UserMapper userMapper;
 
     @Operation(summary = "회원가입")
+    @ResponseStatus(HttpStatus.CREATED)
     @ApiResponse(responseCode = "201", description = "CREATED", content = @Content(schema = @Schema(implementation = UserDto.Response.class)))
     @PostMapping(value = "/join", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> joinUser(@RequestBody UserDto.Post requestBody) {
+    public String joinUser(@RequestBody @Validated UserDto.Post requestBody) {
         User response = userService.createUser(requestBody);
-        return new ResponseEntity<>(userMapper.userToUserResponseDto(response), HttpStatus.CREATED);
+        return "회원가입이 완료되었습니다.";
 
     }
 

--- a/server/src/main/java/com/codestates/team5/dailyclub/user/dto/UserDto.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/user/dto/UserDto.java
@@ -1,12 +1,15 @@
 package com.codestates.team5.dailyclub.user.dto;
 
 import com.codestates.team5.dailyclub.image.dto.UserImageDto;
+import com.codestates.team5.dailyclub.validator.annotation.Unique;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 
@@ -19,12 +22,22 @@ public class UserDto {
     @Schema(name = "회원 가입 API 스펙", title = "회원 가입 API 스펙")
     public static class Post {
         @Schema(description = "로그인 ID", example = "meow123")
+        @Length(min = 5, max = 30)
+        @NotNull
+        @Unique("loginId")
         private String loginId;
+        @Length(min = 6, max = 18)
         @Schema(description = "패스워드", example = "rerewr")
+        @NotNull
         private String password;
+        @Length(min = 2, max = 10)
         @Schema(description = "닉네임", example = "냥냥")
+        @NotNull
+        @Unique("nickname")
         private String nickname;
+        @NotNull
         @Schema(description = "email", example = "abcd@sdfe.com")
+        @Unique("email")
         private String email;
     }
     @Getter
@@ -34,10 +47,12 @@ public class UserDto {
     public static class Patch {
         @Schema(description = "유저 ID", example = "1")
         private Long id;
+        @Length(min = 2, max = 10)
         @Schema(description = "닉네임", example = "냥냥")
         private String nickname;
         @Schema(description = "프로필 이미지 ID")
         private Long userImageId;
+        @Length(min = 1, max = 200)
         @Schema(description = "자기소개", example = "자기소개 입니다.")
         private String introduction;
     }

--- a/server/src/main/java/com/codestates/team5/dailyclub/user/entity/User.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/user/entity/User.java
@@ -68,8 +68,16 @@ public class User extends Auditable {
         }
     }
 
-    public void update(String nickname, String introduction) {
+    public void updateAll(String nickname, String introduction) {
         this.nickname = nickname;
+        this.introduction = introduction;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateIntroduction(String introduction) {
         this.introduction = introduction;
     }
 

--- a/server/src/main/java/com/codestates/team5/dailyclub/user/service/UserService.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/user/service/UserService.java
@@ -3,6 +3,8 @@ package com.codestates.team5.dailyclub.user.service;
 import com.codestates.team5.dailyclub.image.entity.UserImage;
 import com.codestates.team5.dailyclub.image.repository.UserImageRepository;
 import com.codestates.team5.dailyclub.image.util.ImageUtils;
+import com.codestates.team5.dailyclub.refreshToken.RefreshToken;
+import com.codestates.team5.dailyclub.refreshToken.RefreshTokenRepository;
 import com.codestates.team5.dailyclub.throwable.entity.BusinessLogicException;
 import com.codestates.team5.dailyclub.throwable.entity.ExceptionCode;
 import com.codestates.team5.dailyclub.user.dto.UserDto;
@@ -50,7 +52,19 @@ public class UserService {
             throw new BusinessLogicException(ExceptionCode.CANNOT_UPDATE_USERS);
         }
 
-        findUser.update(userFromPatchDto.getNickname(), userFromPatchDto.getIntroduction());
+        //닉네임, 자기소개 둘 다 변경 요청
+        if(userFromPatchDto.getNickname() != findUser.getNickname()
+                && userFromPatchDto.getIntroduction() != findUser.getIntroduction()) {
+            findUser.updateAll(userFromPatchDto.getNickname(), userFromPatchDto.getIntroduction());
+            //닉네임 변경 요청
+        }else if(userFromPatchDto.getNickname() != findUser.getNickname()
+                && userFromPatchDto.getIntroduction() == findUser.getIntroduction()) {
+            findUser.updateNickname(userFromPatchDto.getNickname());
+            //자기소개 변경 요청
+        }else if(userFromPatchDto.getNickname() == findUser.getNickname()
+                && userFromPatchDto.getIntroduction() != findUser.getIntroduction()) {
+            findUser.updateIntroduction(userFromPatchDto.getIntroduction());
+        }
 
         if(imageFile == null && userImageId == null) {
             return userRepository.save(findUser);


### PR DESCRIPTION
UserDto에 회원가입시 유효성 검사를 진행하기 위한 어노테이션을 추가하였습니다.
회원 정보 수정시 닉네임과 자기소개가 null로 들어올 수 있는 부분을 고려하여 메소드를 추가로 만들었습니다.
회원 탈퇴를 위한 onDelete를 user와 연관관계를 맺고 있는 곳 마다 진행했습니다.