### PR TITLE
[FE] feat: Login, SignUp Validation, MyPage Logout 수정

### DIFF
--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -13,6 +13,7 @@ import OauthTitle from 'components/OAuth/OauthTitle';
 import { useAppDispatch } from 'stores/hooks';
 import { fetchUserInfo, getUserId } from 'stores/userInfoSlice';
 import { parseJwt } from 'utils/parseJwt';
+import { useState } from 'react';
 
 const LoginContainer = styled.div`
   margin: 0 auto;
@@ -50,6 +51,7 @@ export default function Login() {
     handleSubmit,
     formState: { errors },
   } = useForm<LoginVal>();
+  const [errMsg, setErrMsg] = useState('');
 
   const handleLoginSubmit: SubmitHandler<LoginVal> = (data) => {
     API.login(data)
@@ -73,7 +75,11 @@ export default function Login() {
       .then((res) => {
         navigate(-1);
       })
-      .catch((error) => alert('ID 또는 비밀번호가 일치하지 않습니다.'));
+      .catch((error) => {
+        if (error.response.data === 'login fail') {
+          setErrMsg('ID 또는 비밀번호가 일치하지 않습니다.');
+        }
+      });
   };
 
   return (
@@ -95,6 +101,7 @@ export default function Login() {
           {errors.password && errors.password.type === 'required' && (
             <FormError>비밀번호를 입력해주세요.</FormError>
           )}
+          <FormError>{errMsg && errMsg}</FormError>
           <OauthBtn type="submit">로그인</OauthBtn>
         </LoginForm>
         <WrapperColumn>

--- a/client/src/pages/MyPage.tsx
+++ b/client/src/pages/MyPage.tsx
@@ -655,11 +655,17 @@ function MyPage() {
     setUserImages('');
     setOrgImg('');
   };
-  const handleMyPageLogout = () => {
+  const handleMyPageLogout = async () => {
     dispatch(logoutUser());
-    removeLocalStorage('access_token');
-    removeLocalStorage('refresh_token');
-    navigate('/');
+    await axios
+      .get(`${process.env.REACT_APP_DEV_URL}/logout/${userId}`)
+      .then((res) => console.log(res))
+      .then(() => {
+        removeLocalStorage('access_token');
+        removeLocalStorage('refresh_token');
+        navigate('/');
+      })
+      .catch((err) => console.log(err));
   };
 
   return (

--- a/client/src/pages/SignUp.tsx
+++ b/client/src/pages/SignUp.tsx
@@ -8,6 +8,7 @@ import OauthBtn from 'components/OAuth/OauthBtn';
 import OauthGoogleBtn from 'components/OAuth/OauthGoogleBtn';
 import OauthNaverBtn from 'components/OAuth/OauthNaverBtn';
 import OauthTitle from 'components/OAuth/OauthTitle';
+import { useState } from 'react';
 
 const SignUpContainer = styled.div`
   margin: 0 auto;
@@ -44,8 +45,16 @@ export default function SignUp() {
     handleSubmit,
     formState: { errors },
   } = useForm<SignUpVal>();
+  const [idErrMsg, setIdErrMsg] = useState('');
+  const [nicknameErrMsg, setNicknameErrMsg] = useState('');
+  const [emailErrMsg, setEmailErrMsg] = useState('');
+  const [pwdErrMsg, setPwdErrMsg] = useState('');
 
   const handleLoginSubmit: SubmitHandler<SignUpVal> = (data) => {
+    setEmailErrMsg('');
+    setNicknameErrMsg('');
+    setIdErrMsg('');
+    setPwdErrMsg('');
     /** 회원가입 API */
     axios
       .post(`${URL}/join`, data, {
@@ -57,7 +66,15 @@ export default function SignUp() {
         navigate('/login');
         console.log('회원등록 응답 :', res);
       })
-      .catch((err) => console.log(err));
+      .catch((err) => {
+        console.log(err?.response?.data?.fieldErrors);
+        err?.response?.data?.fieldErrors?.map((el: any) => {
+          if (el.field === 'email') setEmailErrMsg(el.reason);
+          if (el.field === 'nickname') setNicknameErrMsg(el.reason);
+          if (el.field === 'loginId') setIdErrMsg(el.reason);
+          if (el.field === 'password') setPwdErrMsg(el.reason);
+        });
+      });
   };
 
   return (
@@ -66,12 +83,22 @@ export default function SignUp() {
         <OauthTitle>J O I N</OauthTitle>
         <SignUpForm onSubmit={handleSubmit(handleLoginSubmit)}>
           <SignUpInput
-            {...register('loginId', { required: true })}
+            {...register('loginId', {
+              required: '아이디를 입력해주세요.',
+              minLength: {
+                value: 5,
+                message: '5자 이상 15자 이하의 아이디를 입력해주세요.',
+              },
+              maxLength: {
+                value: 15,
+                message: '15자 이하의 아이디를 입력해주세요',
+              },
+            })}
             placeholder="아이디"
+            onChange={() => setIdErrMsg('')}
           />
-          {errors.loginId && errors.loginId.type === 'required' && (
-            <FormError>아이디를 입력해주세요.</FormError>
-          )}
+          {errors.loginId && <FormError>{errors.loginId.message}</FormError>}
+          {idErrMsg && <FormError>{idErrMsg}</FormError>}
           <SignUpInput
             {...register('email', {
               required: true,
@@ -79,27 +106,48 @@ export default function SignUp() {
             })}
             type="email"
             placeholder="이메일"
+            onChange={() => setEmailErrMsg('')}
           />
           {errors.email && errors.email.type === 'required' && (
             <FormError>이메일을 입력해주세요.</FormError>
           )}
+          {emailErrMsg && <FormError>{emailErrMsg}</FormError>}
           {errors.email && errors.email.type === 'pattern' && (
             <FormError>{`잘못된 이메일 형식입니다. 예) @email.com`}</FormError>
           )}
           <SignUpInput
-            {...register('password', { required: true })}
+            {...register('password', {
+              required: '비밀번호를 입력해주세요.',
+              minLength: {
+                value: 6,
+                message: '6자 이상 18자 이하의 비밀번호를 입력해주세요.',
+              },
+              maxLength: {
+                value: 18,
+                message: '18자 이하의 비밀번호를 입력해주세요',
+              },
+            })}
             placeholder="비밀번호"
           />
-          {errors.password && errors.password.type === 'required' && (
-            <FormError>비밀번호를 입력해주세요.</FormError>
-          )}
+          {errors.password && <FormError>{errors.password.message}</FormError>}
+          {pwdErrMsg && <FormError>{pwdErrMsg}</FormError>}
           <SignUpInput
-            {...register('nickname', { required: true })}
+            {...register('nickname', {
+              required: '닉네임을 입력해주세요.',
+              minLength: {
+                value: 2,
+                message: '2자 이상 10자 이하의 닉네임을 입력해주세요.',
+              },
+              maxLength: {
+                value: 10,
+                message: '10자 이하의 닉네임을 입력해주세요',
+              },
+            })}
             placeholder="닉네임"
+            onChange={() => setNicknameErrMsg('')}
           />
-          {errors.nickname && errors.nickname.type === 'required' && (
-            <FormError>닉네임을 입력해주세요.</FormError>
-          )}
+          {errors.nickname && <FormError>{errors.nickname.message}</FormError>}
+          {nicknameErrMsg && <FormError>{nicknameErrMsg}</FormError>}
           <OauthBtn type="submit">회원가입</OauthBtn>
         </SignUpForm>
         <LoginLink>


### PR DESCRIPTION
# Login
- 로그인,비밀번호 유효성 검사

# SignUp
## FE단 유효성 검사
- 밑 사진의 조건들 충족안되면 제출 안됨

<img width="428" alt="스크린샷 2022-10-05 오후 5 59 22" src="https://user-images.githubusercontent.com/77045939/194030235-1749e235-1695-4131-9cc4-200e0514a92f.png">

## BE단 유효성 검사
1. 이미 존재하는 아이디,이메일,닉네임이면  BE에서 주는 에러메시지 출력

![스크린샷 2022-10-05 오후 5 42 11](https://user-images.githubusercontent.com/77045939/194030379-fc1bf4d4-1637-42ee-84d4-ffebc7dd2edc.png)

2. FE단에서 1번 걸렀지만 어떤 방법으로든 제출됐을 때 BE에서 주는 에러메시지 출력

![스크린샷 2022-10-05 오후 5 41 54](https://user-images.githubusercontent.com/77045939/194030409-f0792c1d-4ca6-4c93-8ddd-57f7b9a859ac.png)


# MyPage
- Logout  수정









