### PR TITLE
[FE] fix: MainPage Applicants, chore: Pagination CSS

### DIFF
--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -372,13 +372,13 @@ export default function Main() {
                     <LevelPercent percent={el.minKind} />
                     <ProgProgressBar>
                       <ProgressBar
-                        currentPerson={el.numOfRecruits}
+                        currentPerson={el.numOfApplicants}
                         totalPerson={el.numOfRecruits}
                       />
                     </ProgProgressBar>
                     <ProgWrapper>
                       <ProgPerson>
-                        모집인원 {el.numOfRecruits} / {el.numOfRecruits}
+                        모집인원 {el.numOfApplicants} / {el.numOfRecruits}
                       </ProgPerson>
                       <ProgDate>
                         {Math.floor(

--- a/client/src/pagination/Pagination.tsx
+++ b/client/src/pagination/Pagination.tsx
@@ -20,23 +20,27 @@ const Nav = styled.nav`
 
 const Button = styled.button`
   border: none;
-  border-radius: 5px;
+  /* border-radius: 5px; */
   padding: 8px;
   margin: 0;
-  background: #ff5100;
-  color: white;
+  /* background: #ff5100; */
+  color: black;
   font-size: 1rem;
 
   &:hover {
-    background: #ff5924;
+    color: #ff5924;
     cursor: pointer;
   }
 
   &[disabled] {
-    background: grey;
+    /* background: grey; */
     cursor: revert;
     transform: revert;
   }
+
+  &:active{
+    color: #c98169;
+  } 
 `;
 
 function Pagination({ list, page, setPage }: PaginationProps) {
@@ -54,7 +58,7 @@ function Pagination({ list, page, setPage }: PaginationProps) {
     <>
       <Nav>
         <Button onClick={() => setPage(page - 1)} disabled={page === 1}>
-          &lt;
+           &#9664;
         </Button>
         {numPages.map((el) => (
           <Button key={el} onClick={() => setPage(el)} disabled={page === el}>
@@ -66,7 +70,7 @@ function Pagination({ list, page, setPage }: PaginationProps) {
           onClick={() => setPage(page + 1)}
           disabled={page === numPages.length}
         >
-          &gt;
+          &#9654;
         </Button>
       </Nav>
     </>


### PR DESCRIPTION
# 작업내용
- ## 메인 페이지의 신청인원 현황
  - ### 메인 페이지의 프로그램 리스트에서 현재 신청인원 현황이 표시되지 않는 것을 표시되도록 수정했습니다.
    - 신청 인원 0명일 때,
    ![0aud](https://user-images.githubusercontent.com/67827456/194043381-23315e31-3c07-4bab-aed2-ca5ae82f1694.png)
    - 신청 인원 1명일 때,
    ![1aud](https://user-images.githubusercontent.com/67827456/194043592-2653ce21-06d3-476a-b13b-c7c1f786968b.png)


- ## 페이지네이션 CSS 수정
  - ### 데일리 클럽에서 사용되는 페이지네이션의 CSS를 가독성 있게 수정했습니다.
      - 기본
      ![zmfflrwjs](https://user-images.githubusercontent.com/67827456/194044582-29d79cce-c482-478a-8fc3-dd7dd2fc2534.png)
      - hover
      ![ghqj](https://user-images.githubusercontent.com/67827456/194044574-858ed713-1354-4a3f-81fd-bc7d26381352.png)
      - active
      ![zmfflr](https://user-images.githubusercontent.com/67827456/194044581-ada9004e-85e5-4de0-a919-0703c61cf96a.png)
# 특이사항
- 페이지네이션 ( <, > ) 두 개의 특수기호를 ( ◀, ▶ )으로 변경.