### PR TITLE
[FE] Review 추가, dday 수정

### DIFF
--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -73,7 +73,8 @@ export default function Login() {
         // console.log('토큰해부', decodedAccess);
       })
       .then((res) => {
-        navigate(-1);
+        // navigate(-1);
+        navigate('/');
       })
       .catch((error) => {
         if (error.response.data === 'login fail') {

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -383,11 +383,14 @@ export default function Main() {
                         모집인원 {el.numOfApplicants} / {el.numOfRecruits}
                       </ProgPerson>
                       <ProgDate>
-                        {Math.floor(
-                          (+new Date(el.programDate) - +new Date()) /
-                            (1000 * 60 * 60 * 24)
-                        )}
-                        일 남음
+                        {el?.programDate === getToday()
+                          ? '오늘 마감'
+                          : Math.floor(
+                              (+new Date(el.programDate) - +new Date()) /
+                                (1000 * 60 * 60 * 24)
+                            ) +
+                            1 +
+                            '일 남음'}
                       </ProgDate>
                     </ProgWrapper>
                   </Link>

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -32,6 +32,7 @@ const FilterContainer = styled.div`
   justify-content: space-between;
 `;
 const DateInput = styled.input`
+  all: unset;
   height: 30px;
   width: 115px;
   border: 0.7px solid lightGrey;
@@ -70,6 +71,7 @@ const WrapLevel = styled.div`
   cursor: default;
 `;
 const WrapLevelRangeInput = styled.input`
+  all: unset;
   width: 80%;
   height: 3px;
   background: #ff5924;
@@ -268,7 +270,7 @@ export default function Main() {
                 min={getToday()}
               />
               <LevelRange onClick={() => setLevelOpened(!levelOpened)}>
-                친절도 &nbsp;{minKindVal}%
+                친절도 &nbsp;{rangeValue}%
                 <img src={QuestionMark} alt="question mark" />
                 <img src={DownArrow} alt="down arrow" />
                 {levelOpened ? (
@@ -285,7 +287,7 @@ export default function Main() {
                       max={100}
                       step={1}
                       onChange={(e) => setRangeValue(e.target.value)}
-                      defaultValue={minKindVal}
+                      defaultValue={rangeValue}
                       onMouseUp={() =>
                         setParamsData({ ...paramsData, minKind: rangeValue })
                       }

--- a/client/src/pages/MyPage.tsx
+++ b/client/src/pages/MyPage.tsx
@@ -24,6 +24,7 @@ import { removeLocalStorage } from 'apis/localStorage';
 
 const MyPageContainer = styled.div`
   display: flex;
+  margin-bottom: 23rem;
 `;
 
 /* 프로필 부분 */

--- a/client/src/pages/MyPage.tsx
+++ b/client/src/pages/MyPage.tsx
@@ -278,7 +278,7 @@ function MyPage() {
           `${DEV_URL}/api/applies/mypage?page=${page}&size=4&userId=${params.userId}`
         )
         .then((res) => {
-          console.log(res?.data.data);
+          // console.log(res?.data.data);
           setPrograms(res.data.data);
           setPageList(res.data.pageInfo);
         });

--- a/client/src/pages/MyPage.tsx
+++ b/client/src/pages/MyPage.tsx
@@ -278,7 +278,7 @@ function MyPage() {
           `${DEV_URL}/api/applies/mypage?page=${page}&size=4&userId=${params.userId}`
         )
         .then((res) => {
-          // console.log(res?.data.data);
+          console.log(res?.data.data);
           setPrograms(res.data.data);
           setPageList(res.data.pageInfo);
         });
@@ -377,7 +377,8 @@ function MyPage() {
                     </ClubInfo>
                   </CardLeftWrapper>
                 </Link>
-                {compareWithToday(el?.program?.programDate) === '모임종료' ? (
+                {compareWithToday(el?.program?.programDate) === '모임종료' &&
+                el?.reviewStatus === 'UNREVIEWED' ? (
                   <ReviewBtn
                     onClick={() => handleReviewOpen(el?.id, el?.program?.id)}
                   >
@@ -435,11 +436,6 @@ function MyPage() {
                     </ClubInfo>
                   </CardLeftWrapper>
                 </Link>
-                {compareWithToday(el?.programDate) === '모임종료' ? (
-                  <ReviewBtn onClick={() => handleReviewOpen(el?.id, el?.id)}>
-                    리뷰작성
-                  </ReviewBtn>
-                ) : null}
               </ClubItem>
             ))}
           </ClubContainer>

--- a/client/src/pages/ReviewCreate.tsx
+++ b/client/src/pages/ReviewCreate.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { useNavigate, useParams } from 'react-router-dom';
 import axios from 'axios';
 import Layout from 'components/Layout';
+import { useAppSelector } from 'stores/hooks';
 
 const ReviewContainer = styled.div`
   margin-bottom: 15rem;
@@ -53,6 +54,8 @@ export default function ReviewCreate() {
   const [badMember, setBadMember] = useState<number>();
   const [score, setScore] = useState<number>(0);
   const [writerInfo, setWriterInfo] = useState<any>({});
+  const { userId } = useAppSelector((state) => state.userInfo);
+  // console.log(userId);
 
   const surveyScoreList = [
     { content: '매우 만족', score: 2 },
@@ -66,7 +69,10 @@ export default function ReviewCreate() {
     await axios
       .get(`${URL}/api/applies?page=1&size=4&programId=${programId}`)
       .then((res) => {
-        setMembers(res.data.data);
+        const exceptMe = res?.data?.data?.filter(
+          (el: any) => el?.user?.id !== userId
+        );
+        setMembers(exceptMe);
       });
   };
   const getProgramWriter = async () => {

--- a/client/src/pages/ReviewCreate.tsx
+++ b/client/src/pages/ReviewCreate.tsx
@@ -55,7 +55,6 @@ export default function ReviewCreate() {
   const [score, setScore] = useState<number>(0);
   const [writerInfo, setWriterInfo] = useState<any>({});
   const { userId } = useAppSelector((state) => state.userInfo);
-  // console.log(userId);
 
   const surveyScoreList = [
     { content: '매우 만족', score: 2 },
@@ -73,6 +72,7 @@ export default function ReviewCreate() {
           (el: any) => el?.user?.id !== userId
         );
         setMembers(exceptMe);
+        // console.log(exceptMe); ////
       });
   };
   const getProgramWriter = async () => {
@@ -91,7 +91,7 @@ export default function ReviewCreate() {
 
   const reviewBody = {
     applyId: Number(applyId),
-    likes: goodMembers?.size !== 0 ? Array.from(goodMembers) : '',
+    likes: goodMembers?.size !== 0 ? Array.from(goodMembers) : [],
     hate: badMember,
     score: score,
   };
@@ -100,7 +100,7 @@ export default function ReviewCreate() {
 
   const handleReviewSubmit = async () => {
     await axios.post(`${URL}/api/reviews`, reviewBody).then((res) => {
-      if (res.data === 'success') {
+      if (res.status === 200) {
         navigate(-1);
       }
     });
@@ -129,12 +129,17 @@ export default function ReviewCreate() {
 
   const handleCheckBadMember = (target: any) => {
     const checkBadMember = document.getElementsByName('onlyCheckedBad');
+
     if (checkBadMember) {
       checkBadMember.forEach((item: any) => {
         item.checked = false;
+        setBadMember(undefined);
       });
-      target.checked = true;
-      setBadMember(Number(target.value));
+      // 좋은멤버로 선택안한 멤버만 나쁜멤버로 선택하게 하기
+      if (Array.from(goodMembers).includes(Number(target.value)) === false) {
+        target.checked = true;
+        setBadMember(Number(target.value));
+      }
     }
   };
 

--- a/client/src/pages/SignUp.tsx
+++ b/client/src/pages/SignUp.tsx
@@ -64,10 +64,9 @@ export default function SignUp() {
       })
       .then((res) => {
         navigate('/login');
-        console.log('회원등록 응답 :', res);
+        // console.log('회원등록 응답 :', res);
       })
       .catch((err) => {
-        console.log(err?.response?.data?.fieldErrors);
         err?.response?.data?.fieldErrors?.map((el: any) => {
           if (el.field === 'email') setEmailErrMsg(el.reason);
           if (el.field === 'nickname') setNicknameErrMsg(el.reason);


### PR DESCRIPTION
# 리뷰 추가
- 마이페이지에서 리뷰버튼 분기 - reviewStatus로 리뷰버튼 비활성화
- 멤버 항목에서 본인 제외
- 좋은멤버로 선택했으면 나쁜멤버로 선택불가하게 하기

# 메인 dday 수정
- d-day 오늘이면 `오늘마감` 메시지 출력
- d-day가 내일이면 `1일 남음`으로 변경함 (변경 전: `0일 남음`)
# 마이페이지 css 수정
- 내부 컨텐트없으면 footer가 많이 올라와서 `margin-bottom` 추가
# Login 성공 처리 수정
- `질문 상세페이지 => 로그인` 하면 navigate(-1) 이전페이지(질문상세)로 이동하게 했는데
- 문제: `회원가입 => 로그인` 성공시에도 이전페이지(회원가입)으로 이동해버림
- 다시 navigate('/') 메인 페이지로 이동하는걸로 원상복귀시킴

# 참고사항
- 해결해야 할 것 - 리뷰페이지에서 나쁜멤버 먼저 선택하고 좋은멤버 선택하면 좋은멤버에서도 같이 선택되는 문제
