### PR TITLE
[BE] fix: fix the way of initializing targetEnumClass field in AbstractEnumAttributeConverter.java

### DIFF
--- a/server/src/main/java/com/codestates/team5/dailyclub/common/enumeration/converter/AbstractEnumAttributeConverter.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/common/enumeration/converter/AbstractEnumAttributeConverter.java
@@ -2,6 +2,7 @@ package com.codestates.team5.dailyclub.common.enumeration.converter;
 
 import com.codestates.team5.dailyclub.common.enumeration.CommonEnum;
 import com.codestates.team5.dailyclub.common.util.EnumValueConvertUtils;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -9,13 +10,13 @@ import javax.persistence.AttributeConverter;
 
 @Slf4j
 @Getter
+@AllArgsConstructor
 public class AbstractEnumAttributeConverter<E extends Enum<E> & CommonEnum> implements AttributeConverter<E, String> {
 
     private Class<E> targetEnumClass;
 
     @Override
     public String convertToDatabaseColumn(E attribute) {
-        targetEnumClass = attribute.getDeclaringClass();
         return EnumValueConvertUtils.toDescription(attribute);
     }
 

--- a/server/src/main/java/com/codestates/team5/dailyclub/program/util/converter/LocationConverter.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/program/util/converter/LocationConverter.java
@@ -10,5 +10,7 @@ import javax.persistence.Converter;
  */
 @Converter
 public class LocationConverter extends AbstractEnumAttributeConverter<Program.Location> {
-
+    public LocationConverter() {
+        super(Program.Location.class);
+    }
 }

--- a/server/src/main/java/com/codestates/team5/dailyclub/program/util/converter/ProgramStatusConverter.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/program/util/converter/ProgramStatusConverter.java
@@ -7,5 +7,7 @@ import javax.persistence.Converter;
 
 @Converter
 public class ProgramStatusConverter extends AbstractEnumAttributeConverter<Program.ProgramStatus> {
-
+    public ProgramStatusConverter() {
+        super(Program.ProgramStatus.class);
+    }
 }


### PR DESCRIPTION
Issue에  적은 것처럼 단방향일 때만 targetEnumClass 필드가 초기화되고 있어서

아예 AbstractEnumAttributeConverter 클래스를 상속 받는 자식 클래스에서 부모 클래스의 필드를 초기화하는 방식으로 변경했습니다.