### PR TITLE
[BE] feat: handle Notification Events

### DIFF
--- a/server/src/main/java/com/codestates/team5/dailyclub/apply/service/ApplyService.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/apply/service/ApplyService.java
@@ -2,11 +2,11 @@ package com.codestates.team5.dailyclub.apply.service;
 
 import com.codestates.team5.dailyclub.apply.entity.Apply;
 import com.codestates.team5.dailyclub.apply.repository.ApplyRepository;
+import com.codestates.team5.dailyclub.notification.event.NotificationEventPublisher;
 import com.codestates.team5.dailyclub.program.entity.Program;
 import com.codestates.team5.dailyclub.program.repository.ProgramRepository;
 import com.codestates.team5.dailyclub.program.service.ProgramService;
 import com.codestates.team5.dailyclub.throwable.entity.BusinessLogicException;
-import com.codestates.team5.dailyclub.throwable.entity.ExceptionCode;
 import com.codestates.team5.dailyclub.user.entity.User;
 import com.codestates.team5.dailyclub.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +19,18 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
+import static com.codestates.team5.dailyclub.notification.entity.Notification.NotificationType.APPLY_COMPLETE;
+import static com.codestates.team5.dailyclub.throwable.entity.ExceptionCode.ALREADY_APPLIED;
+import static com.codestates.team5.dailyclub.throwable.entity.ExceptionCode.APPLY_NOT_FOUND;
+import static com.codestates.team5.dailyclub.throwable.entity.ExceptionCode.CANNOT_APPLY_MINE;
+import static com.codestates.team5.dailyclub.throwable.entity.ExceptionCode.CANNOT_CANCEL_DDAY;
+import static com.codestates.team5.dailyclub.throwable.entity.ExceptionCode.CANNOT_CANCEL_OTHERS;
+import static com.codestates.team5.dailyclub.throwable.entity.ExceptionCode.FULL_OF_APPLY;
+import static com.codestates.team5.dailyclub.throwable.entity.ExceptionCode.LOWER_THAN_MIN_KIND;
+import static com.codestates.team5.dailyclub.throwable.entity.ExceptionCode.PROGRAM_ALREADY_ENDED;
+import static com.codestates.team5.dailyclub.throwable.entity.ExceptionCode.PROGRAM_NOT_FOUND;
+import static com.codestates.team5.dailyclub.throwable.entity.ExceptionCode.USER_NOT_FOUND;
+
 @Service
 @Transactional
 @Slf4j
@@ -29,35 +41,36 @@ public class ApplyService {
     private final ApplyRepository applyRepository;
     private final UserRepository userRepository;
     private final ProgramRepository programRepository;
+    private final NotificationEventPublisher notificationEventPublisher;
 
     public Apply createApply(Long loginUserId, Long programId) {
         //유저 존재 확인
         User userById = userRepository.findById(loginUserId).orElseThrow(() ->
-            new BusinessLogicException(ExceptionCode.USER_NOT_FOUND)
+            new BusinessLogicException(USER_NOT_FOUND)
         );
         //프로그램 존재 확인
         Program programById = programRepository.findById(programId).orElseThrow(() ->
-            new BusinessLogicException(ExceptionCode.PROGRAM_NOT_FOUND)
+            new BusinessLogicException(PROGRAM_NOT_FOUND)
         );
         //본인 프로그램에 신청하려는 건지 확인
         if (programById.getUser().getId().equals(loginUserId)) {
-            throw new BusinessLogicException(ExceptionCode.CANNOT_APPLY_MINE);
+            throw new BusinessLogicException(CANNOT_APPLY_MINE);
         }
         //이미 신청한 프로그램인지 확인
         if (applyRepository.existsByUserAndProgram(userById, programById)) {
-            throw new BusinessLogicException(ExceptionCode.ALREADY_APPLIED);
+            throw new BusinessLogicException(ALREADY_APPLIED);
         }
         //Apply 등록 전 현재 programStatus 체크
         if (programById.getProgramStatus() == Program.ProgramStatus.IMPOSSIBLE) {
-            throw new BusinessLogicException(ExceptionCode.FULL_OF_APPLY);
+            throw new BusinessLogicException(FULL_OF_APPLY);
         }
         //최소 신청 가능 친절 %보다 본인의 친절 %가 높은지 확인
         if (programById.getMinKind() > userById.getKind()) {
-            throw new BusinessLogicException(ExceptionCode.LOWER_THAN_MIN_KIND);
+            throw new BusinessLogicException(LOWER_THAN_MIN_KIND);
         }
         //종료된 프로그램인지 확인
         if (programById.getProgramDate().isBefore(LocalDate.now())) {
-            throw new BusinessLogicException(ExceptionCode.PROGRAM_ALREADY_ENDED);
+            throw new BusinessLogicException(PROGRAM_ALREADY_ENDED);
         }
 
         Apply apply = Apply.builder()
@@ -75,13 +88,16 @@ public class ApplyService {
         //program dirty checking
         programById.updateProgramStatus(updatedProgramStatus);
 
+        //신청 완료 알림 보내기
+        notificationEventPublisher.publish(loginUserId, programId, APPLY_COMPLETE);
+
         return savedApply;
     }
 
     public Page<Apply> findAppliesByProgramId(int page, int size, Long programId) {
         //프로그램 존재 확인
         Program programById = programRepository.findById(programId).orElseThrow(() ->
-            new BusinessLogicException(ExceptionCode.PROGRAM_NOT_FOUND)
+            new BusinessLogicException(PROGRAM_NOT_FOUND)
         );
 
         PageRequest pageRequest = PageRequest.of(page, size, Sort.by("id").descending());
@@ -95,7 +111,7 @@ public class ApplyService {
     public Page<Apply> findAppliesByUserId(int page, int size, Long userId) {
         //유저 존재 확인
         User userById = userRepository.findById(userId).orElseThrow(() ->
-            new BusinessLogicException(ExceptionCode.USER_NOT_FOUND)
+            new BusinessLogicException(USER_NOT_FOUND)
         );
 
         PageRequest pageRequest = PageRequest.of(page, size, Sort.by("id").descending());
@@ -105,22 +121,22 @@ public class ApplyService {
     public void deleteApply(Long loginUserId, Long applyId) {
         //유저 존재 확인
         User userById = userRepository.findById(loginUserId).orElseThrow(() ->
-            new BusinessLogicException(ExceptionCode.USER_NOT_FOUND)
+            new BusinessLogicException(USER_NOT_FOUND)
         );
 
         //신청 여부 확인
         Apply applyById = applyRepository.findById(applyId).orElseThrow(() ->
-            new BusinessLogicException(ExceptionCode.APPLY_NOT_FOUND)
+            new BusinessLogicException(APPLY_NOT_FOUND)
         );
 
         //신청한 본인이 취소하는지 확인
         if (!applyById.getUser().getId().equals(loginUserId)) {
-            throw new BusinessLogicException(ExceptionCode.CANNOT_CANCEL_OTHERS);
+            throw new BusinessLogicException(CANNOT_CANCEL_OTHERS);
         }
 
         //당일 신청 취소 불가
         if (applyById.getProgram().getProgramDate().isEqual(LocalDate.now())) {
-            throw new BusinessLogicException(ExceptionCode.CANNOT_CANCEL_DDAY);
+            throw new BusinessLogicException(CANNOT_CANCEL_DDAY);
         }
 
         //신청 삭제
@@ -128,7 +144,7 @@ public class ApplyService {
 
         //프로그램 조회
         Program programById = programRepository.findById(applyById.getProgram().getId()).orElseThrow(() ->
-            new BusinessLogicException(ExceptionCode.PROGRAM_NOT_FOUND)
+            new BusinessLogicException(PROGRAM_NOT_FOUND)
         );
 
         //새로운 프로그램 상태

--- a/server/src/main/java/com/codestates/team5/dailyclub/config/SecurityConfig.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/config/SecurityConfig.java
@@ -87,6 +87,7 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
 
         configuration.addAllowedOrigin("http://localhost:3000");
+        configuration.addAllowedOrigin("http://dailyclub.site");
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
         configuration.addExposedHeader("Authorization");

--- a/server/src/main/java/com/codestates/team5/dailyclub/jwt/TokenProvider.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/jwt/TokenProvider.java
@@ -43,7 +43,7 @@ public class TokenProvider {
 
         return JWT.create()
                 .withSubject("JWT Access Token")
-                .withExpiresAt(new Date(System.currentTimeMillis() + (60 * 1000)))
+                .withExpiresAt(new Date(System.currentTimeMillis() + (60 * 1000 * 30)))
                 .withClaim("id", authDetails.getUser().getId())
                 .withClaim("loginId", authDetails.getUsername())
                 .sign(Algorithm.HMAC512(accessKey));

--- a/server/src/main/java/com/codestates/team5/dailyclub/notification/dto/NotificationDto.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/notification/dto/NotificationDto.java
@@ -21,6 +21,9 @@ public class NotificationDto {
         @Schema(description = "알림 ID")
         private Long id;
 
+        @Schema(description = "유저 ID")
+        private Long userId;
+
         @Schema(description = "프로그램 ID")
         private Long programId;
 

--- a/server/src/main/java/com/codestates/team5/dailyclub/notification/entity/Notification.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/notification/entity/Notification.java
@@ -38,6 +38,7 @@ public class Notification extends Auditable {
     @NotNull
     private NotificationType notificationType;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @NotNull
     private StatusRead statusRead = StatusRead.UNREAD;
@@ -67,7 +68,9 @@ public class Notification extends Auditable {
      */
     @Getter
     public enum NotificationType {
-        UPDATE("UPDATE"), DDAY("DDAY"), APPLY_COMPLETE("APPLY_COMPLETE");
+        UPDATE("UPDATE"),
+        DDAY("DDAY"),
+        APPLY_COMPLETE("APPLY_COMPLETE");
 
         private String type;
 

--- a/server/src/main/java/com/codestates/team5/dailyclub/notification/event/NotificationEvent.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/notification/event/NotificationEvent.java
@@ -1,0 +1,23 @@
+package com.codestates.team5.dailyclub.notification.event;
+
+import com.codestates.team5.dailyclub.notification.entity.Notification;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class NotificationEvent extends ApplicationEvent {
+    private final Long userId;
+    private final Long programId;
+    private final Notification.NotificationType type;
+
+    public NotificationEvent(Object source,
+                             Long userId,
+                             Long programId,
+                             Notification.NotificationType type) {
+        super(source);
+        this.userId = userId;
+        this.programId = programId;
+        this.type = type;
+    }
+
+}

--- a/server/src/main/java/com/codestates/team5/dailyclub/notification/event/NotificationEventListener.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/notification/event/NotificationEventListener.java
@@ -1,0 +1,36 @@
+package com.codestates.team5.dailyclub.notification.event;
+
+import com.codestates.team5.dailyclub.emitter.service.EmitterService;
+import com.codestates.team5.dailyclub.notification.repository.NotificationRepository;
+import com.codestates.team5.dailyclub.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationEventListener implements ApplicationListener<NotificationEvent> {
+
+    private final NotificationService notificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Override
+    public void onApplicationEvent(NotificationEvent event) {
+        log.info(
+            "[NotificationEvent Listening] userId={}, programId={}, type={}",
+            event.getUserId(),
+            event.getProgramId(),
+            event.getType()
+        );
+
+        notificationService.createNotification(event.getUserId(),
+                                                event.getProgramId(),
+                                                event.getType());
+    }
+}

--- a/server/src/main/java/com/codestates/team5/dailyclub/notification/event/NotificationEventPublisher.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/notification/event/NotificationEventPublisher.java
@@ -1,0 +1,29 @@
+package com.codestates.team5.dailyclub.notification.event;
+
+import com.codestates.team5.dailyclub.notification.entity.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationEventPublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public void publish(Long userId, Long programId, Notification.NotificationType type) {
+        log.info(
+            "[NotificationEvent Publishing] userId={}, programId={}, type={}",
+            userId,
+            programId,
+            type
+        );
+        NotificationEvent event
+            = new NotificationEvent(this, userId, programId, type);
+
+        applicationEventPublisher.publishEvent(event);
+    }
+
+}

--- a/server/src/main/java/com/codestates/team5/dailyclub/notification/mapper/NotificationMapper.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/notification/mapper/NotificationMapper.java
@@ -15,10 +15,12 @@ public interface NotificationMapper {
     default NotificationDto.Response notificationToNotificationResponseDto(Notification notification) {
         return NotificationDto.Response.builder()
                 .id(notification.getId())
+                .userId(notification.getUser().getId())
                 .programId(notification.getProgram().getId())
                 .title(notification.getProgram().getTitle())
                 .status(notification.getStatusRead().getStatus())
                 .type(notification.getNotificationType().getType())
+                .createdDate(notification.getCreatedDate())
                 .build();
     }
 

--- a/server/src/main/java/com/codestates/team5/dailyclub/notification/repository/NotificationRepository.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/notification/repository/NotificationRepository.java
@@ -1,14 +1,16 @@
 package com.codestates.team5.dailyclub.notification.repository;
 
 import com.codestates.team5.dailyclub.notification.entity.Notification;
+import com.codestates.team5.dailyclub.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface NotificationRepository extends JpaRepository <Notification, Long> {
-    @Query("select n from Notification n where n.user.id = :userId order by n.id desc")
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    @Query("select n from Notification n where n.user.id = :userId")
     Page<Notification> findByUserId(PageRequest pageRequest, @Param("userId") Long userId);
 
+    long countByUserAndStatusRead(User userById, Notification.StatusRead statusRead);
 }

--- a/server/src/main/java/com/codestates/team5/dailyclub/notification/service/NotificationService.java
+++ b/server/src/main/java/com/codestates/team5/dailyclub/notification/service/NotificationService.java
@@ -2,6 +2,12 @@ package com.codestates.team5.dailyclub.notification.service;
 
 import com.codestates.team5.dailyclub.notification.entity.Notification;
 import com.codestates.team5.dailyclub.notification.repository.NotificationRepository;
+import com.codestates.team5.dailyclub.program.entity.Program;
+import com.codestates.team5.dailyclub.program.repository.ProgramRepository;
+import com.codestates.team5.dailyclub.throwable.entity.BusinessLogicException;
+import com.codestates.team5.dailyclub.throwable.entity.ExceptionCode;
+import com.codestates.team5.dailyclub.user.entity.User;
+import com.codestates.team5.dailyclub.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -9,7 +15,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
+import static com.codestates.team5.dailyclub.throwable.entity.ExceptionCode.PROGRAM_NOT_FOUND;
 
 @Service
 @Transactional
@@ -17,19 +23,60 @@ import java.util.Optional;
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+    private final ProgramRepository programRepository;
+
+    public Notification createNotification(Long userId, Long programId, Notification.NotificationType type) {
+        //유저 존재 확인
+        User userById = userRepository.findById(userId).orElseThrow(() ->
+            new BusinessLogicException(ExceptionCode.USER_NOT_FOUND)
+        );
+        //프로그램 존재 확인
+        Program programById = programRepository.findById(programId).orElseThrow(() ->
+            new BusinessLogicException(ExceptionCode.PROGRAM_NOT_FOUND)
+        );
+
+        Notification notification = Notification.builder()
+                                        .user(userById)
+                                        .program(programById)
+                                        .notificationType(type)
+                                        .build();
+
+        return notificationRepository.save(notification);
+    }
 
     public Page<Notification> findNotifications(int page, int size, Long loginUserId) {
+        //유저 존재 확인
+        User userById = userRepository.findById(loginUserId).orElseThrow(() ->
+            new BusinessLogicException(ExceptionCode.USER_NOT_FOUND)
+        );
+
         PageRequest pageRequest = PageRequest.of(page, size, Sort.by("id").descending());
         return notificationRepository.findByUserId(pageRequest, loginUserId);
     }
 
-    public void deleteNotification(Long id) {
-        notificationRepository.deleteById(id);
+    public void updateStatusRead(Long loginUserId, Long notificationId) {
+        //유저 존재 확인
+        User userById = userRepository.findById(loginUserId).orElseThrow(() ->
+            new BusinessLogicException(ExceptionCode.USER_NOT_FOUND)
+        );
+        //알림 존재 확인
+        Notification notificationById = notificationRepository.findById(notificationId).orElseThrow(() ->
+            new BusinessLogicException(ExceptionCode.NOTIFICATION_NOT_FOUND)
+        );
+        //본인의 알람을 읽은 것인지 확인
+        if (!notificationById.getUser().getId().equals(loginUserId)) {
+            throw new BusinessLogicException(ExceptionCode.CANNOT_READ_OTHERS_NOTIFICATION);
+        }
+
+        notificationById.changeStatusRead();
     }
 
-    public void updateStatusRead(Long id) {
-        notificationRepository.findById(id)
-                .ifPresent(Notification::changeStatusRead);
+    public long countUnreadNotifications(Long loginUserId) {
+        //유저 존재 확인
+        User userById = userRepository.findById(loginUserId).orElseThrow(() ->
+            new BusinessLogicException(ExceptionCode.USER_NOT_FOUND)
+        );
+        return notificationRepository.countByUserAndStatusRead(userById, Notification.StatusRead.UNREAD);
     }
-
 }


### PR DESCRIPTION
SSE 연결을 제외하고, 알림 리스트 조회, 읽음 표시, 안 읽은 알림 개수에 관한 기능 처리입니다.
notification을 이벤트로 처리했습니다.

프로그램 수정, 프로그램 신청을 하면 NotificationEventPublisher가 NotificationEvent를 publishing하면 NotificationListener가 NotificationEvent를 listening하면서 notification을 테이블에 저장하는 로직입니다.

event로 처리한 이유는 service 계층 간 의존관계를 줄이려고 했기 때문입니다.